### PR TITLE
Quartz First/Last Weekday Support for Cron Expression Descriptor

### DIFF
--- a/CronExpressionDescriptor.Test/TestFormats.cs
+++ b/CronExpressionDescriptor.Test/TestFormats.cs
@@ -170,6 +170,42 @@ namespace CronExpressionDescriptor.Test
         }
 
         [TestMethod]
+        public void TestLastWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the last weekday of the month", ExpressionDescriptor.GetDescription("* * LW * *"));
+        }
+
+        [TestMethod]
+        public void TestLastWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the last weekday of the month", ExpressionDescriptor.GetDescription("* * WL * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the first weekday of the month", ExpressionDescriptor.GetDescription("* * 1W * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the first weekday of the month", ExpressionDescriptor.GetDescription("* * W1 * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the weekday nearest day 5 of the month", ExpressionDescriptor.GetDescription("* * 5W * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the weekday nearest day 5 of the month", ExpressionDescriptor.GetDescription("* * W5 * *"));
+        }
+
+        [TestMethod]
         public void TestTimeOfDayWithSeconds()
         {
             Assert.AreEqual("At 02:02:30 PM", ExpressionDescriptor.GetDescription("30 02 14 * * *"));

--- a/CronExpressionDescriptor/ExpressionDescriptor.cs
+++ b/CronExpressionDescriptor/ExpressionDescriptor.cs
@@ -309,18 +309,37 @@ namespace CronExpressionDescriptor
             string expression = m_expressionParts[3];
             expression = expression.Replace("?", "*");
 
-            if (expression == "L")
+            switch (expression)
             {
-                description = ", on the last day of the month";
-            }
-            else
-            {
-                description = GetSegmentDescription(expression,
-                    ", every day",
-                    (s => s),
-                    (s => s == "1" ? ", every day" : ", every {0} days"),
-                    (s => ", between day {0} and {1} of the month"),
-                    (s => ", on day {0} of the month"));
+                case "L":
+                    description = ", on the last day of the month";
+                    break;
+                case "WL":
+                case "LW":
+                    description = ", on the last weekday of the month";
+                    break;
+                default:
+                    Regex regex = new Regex("(\\dW)|(W\\d)");
+                    if (regex.IsMatch(expression))
+                    {
+                        Match m = regex.Match(expression);
+                        int dayNumber = Int32.Parse(m.Value.Replace("W", ""));
+
+                        string dayString = dayNumber == 1 ? "first weekday" : String.Format("weekday nearest day {0}", dayNumber);
+                        description = String.Format(", on the {0} of the month", dayString);
+
+                        break;
+                    }
+                    else
+                    {
+                        description = GetSegmentDescription(expression,
+                            ", every day",
+                            (s => s),
+                            (s => s == "1" ? ", every day" : ", every {0} days"),
+                            (s => ", between day {0} and {1} of the month"),
+                            (s => ", on day {0} of the month"));
+                        break;
+                    }
             }
 
             return description;


### PR DESCRIPTION
Hey,
I'm using your library for showing a quartz expression in readable format after the user builds the expression using a custom UI js popup.  I was wanting to add support for the first/last weekday which is supported by the Quartz job scheduler we're using.  So, I've added support for LW (last weekday), 1W (first weekday), and (0-31)W for the weekday nearest a particular day of the month. Changes also support the transposed version of each.  I also added some unit tests for each scenario.

Anyway, see what you think and decide if you want to incorporate the changes.  I didn't spend a lot of time on making the code pretty, so there's probably some room for refactoring.

Thanks for posting your project!

--Evan
