### PR TITLE
Support Year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ CronExpressionDescripter.Test/bin
 CronExpressionDescripter.Test/obj
 TestResults
 *.suo
+.DS_Store
+*.userprefs

--- a/CronExpressionDescriptor.Test/TestFormats.cs
+++ b/CronExpressionDescriptor.Test/TestFormats.cs
@@ -258,5 +258,35 @@ namespace CronExpressionDescriptor.Test
         {
             Assert.AreEqual("At 05 minutes past the hour", ExpressionDescriptor.GetDescription("0 5 0/1 * * ?"));
         }
+
+        [TestMethod]
+        public void TestOneYearOnlyWithSeconds()
+        {
+            Assert.AreEqual("Every second, only in 2013", ExpressionDescriptor.GetDescription("* * * * * * 2013"));
+        }
+        
+        [TestMethod]
+        public void TestOneYearOnlyWithoutSeconds()
+        {
+            Assert.AreEqual("Every minute, only in 2013", ExpressionDescriptor.GetDescription("* * * * * 2013"));
+        }
+
+        [TestMethod]
+        public void TestTwoYearsOnly()
+        {
+            Assert.AreEqual("Every minute, only in 2013 and 2014", ExpressionDescriptor.GetDescription("* * * * * 2013,2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange2()
+        {
+            Assert.AreEqual("At 12:23 PM, January through February, 2013 through 2014", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB * 2013-2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange3()
+        {
+            Assert.AreEqual("At 12:23 PM, January through March, 2013 through 2015", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR * 2013-2015"));
+        }
     }
 }

--- a/CronExpressionDescriptor/DescriptionTypeEnum.cs
+++ b/CronExpressionDescriptor/DescriptionTypeEnum.cs
@@ -14,6 +14,7 @@ namespace CronExpressionDescriptor
         HOURS,
         DAYOFWEEK,
         MONTH,
-        DAYOFMONTH
+        DAYOFMONTH,
+        YEAR
     }
 }

--- a/CronExpressionDescriptor/ExpressionDescriptor.cs
+++ b/CronExpressionDescriptor/ExpressionDescriptor.cs
@@ -23,7 +23,7 @@ namespace CronExpressionDescriptor
         {
             m_expression = expression;
             m_options = options;
-            m_expressionParts = new string[6];
+            m_expressionParts = new string[7];
             m_parsed = false;
         }
 
@@ -66,6 +66,9 @@ namespace CronExpressionDescriptor
                     case DescriptionTypeEnum.DAYOFWEEK:
                         description = GetDayOfWeekDescription();
                         break;
+                    case DescriptionTypeEnum.YEAR:
+                        description = GetYearDescription();
+                        break;
                     default:
                         description = GetSecondsDescription();
                         break;
@@ -97,11 +100,13 @@ namespace CronExpressionDescriptor
                 string dayOfMonthDesc = GetDayOfMonthDescription();
                 string monthDesc = GetMonthDescription();
                 string dayOfWeekDesc = GetDayOfWeekDescription();
+                string yearDesc = GetYearDescription();
 
-                description = string.Format("{0}{1}{2}",
+                description = string.Format("{0}{1}{2}{3}",
                     timeSegment,
                     (m_expressionParts[3] == "*" ? dayOfWeekDesc : dayOfMonthDesc),
-                    monthDesc);
+                    monthDesc,
+                    yearDesc);
 
                 description = TransformVerbosity(description);
                 description = TransformCase(description);
@@ -344,6 +349,18 @@ namespace CronExpressionDescriptor
 
             return description;
         }
+
+        private string GetYearDescription()
+        {
+            string description = GetSegmentDescription(m_expressionParts[6],
+                string.Empty,
+               (s => new DateTime(Convert.ToInt32(s), 1, 1).ToString("yyyy")),
+               (s => string.Format(", every {0} years", s)),
+               (s => ", {0} through {1}"),
+               (s => ", only in {0}"));
+			
+            return description;
+		}
 
         protected string GetSegmentDescription(string expression,
             string allDescription,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ License: MIT
 **Features**          
 
  * Supports all cron expression special characters including * / , - ? L W, #.
- * Supports 5 or 6 (w/ seconds) part cron expressions.  Does NOT support Year in cron expression.
+ * Supports 5, 6 (w/ seconds or year), or 7 (w/ seconds and year) part cron expressions.
  * Provides casing options (Sentence, Title, Lower, etc.)
  
 
@@ -231,4 +231,34 @@ If you want to get up and running quickly and just want the library, [visit the 
         public void TestMinutesPastTheHour()
         {
             Assert.AreEqual("At 05 minutes past the hour", ExpressionDescriptor.GetDescription("0 5 0/1 * * ?"));
+        }
+
+        [TestMethod]
+        public void TestOneYearOnlyWithSeconds()
+        {
+            Assert.AreEqual("Every second, only in 2013", ExpressionDescriptor.GetDescription("* * * * * * 2013"));
+        }
+        
+        [TestMethod]
+        public void TestOneYearOnlyWithoutSeconds()
+        {
+            Assert.AreEqual("Every minute, only in 2013", ExpressionDescriptor.GetDescription("* * * * * 2013"));
+        }
+
+        [TestMethod]
+        public void TestTwoYearsOnly()
+        {
+            Assert.AreEqual("Every minute, only in 2013 and 2014", ExpressionDescriptor.GetDescription("* * * * * 2013,2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange2()
+        {
+            Assert.AreEqual("At 12:23 PM, January through February, 2013 through 2014", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB * 2013-2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange3()
+        {
+            Assert.AreEqual("At 12:23 PM, January through March, 2013 through 2015", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR * 2013-2015"));
         }


### PR DESCRIPTION
User can now optionally supply a year part to the cron expression in
the final position. Seconds part is also still optional so the
expression supports 5, 6, or 7 parts with heuristics to determine
whether seconds or years was supplied in the case of 6.
