### PR TITLE
Cron Expression Descriptor for .net 35

### DIFF
--- a/CronExpressionDescriptor.Net35.Test/CronExpressionDescriptor.Net35.Test.csproj
+++ b/CronExpressionDescriptor.Net35.Test/CronExpressionDescriptor.Net35.Test.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EC37F6BE-96D0-434D-AC1A-075C8ADC022D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CronExpressionDescriptor.Net35.Test</RootNamespace>
+    <AssemblyName>CronExpressionDescriptor.Net35.Test</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestCasing.cs" />
+    <Compile Include="TestExceptions.cs" />
+    <Compile Include="TestFormats.cs" />
+    <Compile Include="TestFormats.zh-cn.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CronExpressionDescriptor\CronExpressionDescriptor.csproj">
+      <Project>{BD023841-603A-4B09-A3B1-522664C1E274}</Project>
+      <Name>CronExpressionDescriptor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestFormat.en-us.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/CronExpressionDescriptor.Net35.Test/Properties/AssemblyInfo.cs
+++ b/CronExpressionDescriptor.Net35.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CronExpressionDescriptor.Net35.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("TheTrainline.com")]
+[assembly: AssemblyProduct("CronExpressionDescriptor.Net35.Test")]
+[assembly: AssemblyCopyright("Copyright © TheTrainline.com 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("94e7b1b4-f729-4922-99ee-4bf25ebd1a2d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CronExpressionDescriptor.Net35.Test/TestCasing.cs
+++ b/CronExpressionDescriptor.Net35.Test/TestCasing.cs
@@ -1,0 +1,39 @@
+﻿using System.Globalization;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CronExpressionDescriptor.Net35.Test
+{
+    [TestClass]
+    public class TestCasing
+    {
+        [TestInitialize]
+        public void SetUp()
+        {
+            CultureInfo myCultureInfo = new CultureInfo("en-GB");
+            Thread.CurrentThread.CurrentCulture = myCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = myCultureInfo;
+        }
+
+        [TestMethod]
+        public void TestSentenceCasing()
+        {
+            ExpressionDescriptor ceh = new ExpressionDescriptor("* * * * *", new Options() { CasingType = CasingTypeEnum.Sentence });
+            Assert.AreEqual("Every minute", ceh.GetDescription(DescriptionTypeEnum.FULL));
+        }
+
+        [TestMethod]
+        public void TestTitleCasing()
+        {
+            ExpressionDescriptor ceh = new ExpressionDescriptor("* * * * *", new Options() { CasingType = CasingTypeEnum.Title });
+            Assert.AreEqual("Every Minute", ceh.GetDescription(DescriptionTypeEnum.FULL));
+        }
+
+        [TestMethod]
+        public void TestLowerCasing()
+        {
+            ExpressionDescriptor ceh = new ExpressionDescriptor("* * * * *", new Options() { CasingType = CasingTypeEnum.LowerCase });
+            Assert.AreEqual("every minute", ceh.GetDescription(DescriptionTypeEnum.FULL));
+        }
+    }
+}

--- a/CronExpressionDescriptor.Net35.Test/TestExceptions.cs
+++ b/CronExpressionDescriptor.Net35.Test/TestExceptions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CronExpressionDescriptor.Net35.Test
+{
+    [TestClass]
+    public class TestExceptions
+    {
+        [TestMethod]
+        [ExpectedException(typeof(MissingFieldException))]
+        public void TestNullCronExpressionException()
+        {
+            Options options = new Options() { ThrowExceptionOnParseError = true };
+            ExpressionDescriptor ceh = new ExpressionDescriptor(null, options);
+            ceh.GetDescription(DescriptionTypeEnum.FULL);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(MissingFieldException))]
+        public void TestEmptyCronExpressionException()
+        {
+            Options options = new Options() { ThrowExceptionOnParseError = true };
+            ExpressionDescriptor ceh = new ExpressionDescriptor(null, options);
+            ceh.GetDescription(DescriptionTypeEnum.FULL);
+        }
+
+        [TestMethod]
+        public void TestNullCronExpressionError()
+        {
+            Options options = new Options() { ThrowExceptionOnParseError = false };
+            ExpressionDescriptor ceh = new ExpressionDescriptor(null, options);
+            string description = ceh.GetDescription(DescriptionTypeEnum.FULL);
+            Assert.AreEqual("Field 'ExpressionDescriptor.expression' not found.", ceh.GetDescription(DescriptionTypeEnum.FULL));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void TestInvalidCronExpressionException()
+        {
+            Options options = new Options() { ThrowExceptionOnParseError = true };
+            ExpressionDescriptor ceh = new ExpressionDescriptor("INVALID", options);
+            ceh.GetDescription(DescriptionTypeEnum.FULL);
+        }
+
+        [TestMethod]
+        public void TestInvalidCronExpressionError()
+        {
+            Options options = new Options() { ThrowExceptionOnParseError = false };
+            ExpressionDescriptor ceh = new ExpressionDescriptor("INVALID CRON", options);
+            string description = ceh.GetDescription(DescriptionTypeEnum.FULL);
+            Assert.AreEqual("Error: Expression only has 2 parts.  At least 5 part are required.", ceh.GetDescription(DescriptionTypeEnum.FULL));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void TestInvalidSyntaxException()
+        {
+            Options options = new Options() { ThrowExceptionOnParseError = true };
+            ExpressionDescriptor ceh = new ExpressionDescriptor("* $ * * *", options);
+            string description = ceh.GetDescription(DescriptionTypeEnum.FULL);
+        }
+    }
+}

--- a/CronExpressionDescriptor.Net35.Test/TestFormat.en-us.cs
+++ b/CronExpressionDescriptor.Net35.Test/TestFormat.en-us.cs
@@ -1,0 +1,366 @@
+﻿using System.Globalization;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CronExpressionDescriptor.Net35.Test
+{
+    [TestClass]
+    public class TestFormatsUS
+    {
+        [TestInitialize]
+        public void SetUp()
+        {
+            CultureInfo myCultureInfo = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = myCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = myCultureInfo;
+        }
+
+        [TestMethod]
+        public void TestEveryMinute()
+        {
+           Assert.AreEqual("Every minute", ExpressionDescriptor.GetDescription("* * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery1Minute()
+        {
+            Assert.AreEqual("Every minute", ExpressionDescriptor.GetDescription("*/1 * * * *"));
+            Assert.AreEqual("Every minute", ExpressionDescriptor.GetDescription("0 0/1 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestEveryHour()
+        {
+            Assert.AreEqual("Every hour", ExpressionDescriptor.GetDescription("0 0 * * * ?"));
+            Assert.AreEqual("Every hour", ExpressionDescriptor.GetDescription("0 0 0/1 * * ?"));
+        }
+
+        [TestMethod]
+        public void TestTimeOfDayCertainDaysOfWeek()
+        {
+            Assert.AreEqual("At 11:00 PM, Monday through Friday", ExpressionDescriptor.GetDescription("0 23 ? * MON-FRI"));
+        }
+
+        [TestMethod]
+        public void TestEverySecond()
+        {
+            Assert.AreEqual("Every second", ExpressionDescriptor.GetDescription("* * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery45Seconds()
+        {
+            Assert.AreEqual("Every 45 seconds", ExpressionDescriptor.GetDescription("*/45 * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery5Minutes()
+        {
+            Assert.AreEqual("Every 05 minutes", ExpressionDescriptor.GetDescription("*/5 * * * *"));
+            Assert.AreEqual("Every 10 minutes", ExpressionDescriptor.GetDescription("0 0/10 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestEvery5MinutesOnTheSecond()
+        {
+            Assert.AreEqual("Every 05 minutes", ExpressionDescriptor.GetDescription("0 */5 * * * *"));
+        }
+
+        [TestMethod]
+        public void TestWeekdaysAtTime()
+        {
+            Assert.AreEqual("At 11:30 AM, Monday through Friday", ExpressionDescriptor.GetDescription("30 11 * * 1-5"));
+        }
+
+        [TestMethod]
+        public void TestDailyAtTime()
+        {
+            Assert.AreEqual("At 11:30 AM", ExpressionDescriptor.GetDescription("30 11 * * *"));
+        }
+
+        [TestMethod]
+        public void TestMinuteSpan()
+        {
+            Assert.AreEqual("Every minute between 11:00 AM and 11:10 AM", ExpressionDescriptor.GetDescription("0-10 11 * * *"));
+        }
+
+        [TestMethod]
+        public void TestOneMonthOnly()
+        {
+            Assert.AreEqual("Every minute, only in March", ExpressionDescriptor.GetDescription("* * * 3 *"));
+        }
+
+        [TestMethod]
+        public void TestTwoMonthsOnly()
+        {
+            Assert.AreEqual("Every minute, only in March and June", ExpressionDescriptor.GetDescription("* * * 3,6 *"));
+        }
+
+        [TestMethod]
+        public void TestTwoTimesEachAfternoon()
+        {
+            Assert.AreEqual("At 02:30 PM and 04:30 PM", ExpressionDescriptor.GetDescription("30 14,16 * * *"));
+        }
+
+        [TestMethod]
+        public void TestThreeTimesDaily()
+        {
+            Assert.AreEqual("At 06:30 AM, 02:30 PM and 04:30 PM", ExpressionDescriptor.GetDescription("30 6,14,16 * * *"));
+        }
+
+        [TestMethod]
+        public void TestOnceAWeek()
+        {
+            Assert.AreEqual("At 09:46 AM, only on Monday", ExpressionDescriptor.GetDescription("46 9 * * 1"));
+        }
+
+        [TestMethod]
+        public void TestDayOfMonth()
+        {
+            Assert.AreEqual("At 12:23 PM, on day 15 of the month", ExpressionDescriptor.GetDescription("23 12 15 * *"));
+        }
+
+        [TestMethod]
+        public void TestMonthName()
+        {
+            Assert.AreEqual("At 12:23 PM, only in January", ExpressionDescriptor.GetDescription("23 12 * JAN *"));
+        }
+
+        [TestMethod]
+        public void TestDayOfMonthWithQuestionMark()
+        {
+            Assert.AreEqual("At 12:23 PM, only in January", ExpressionDescriptor.GetDescription("23 12 ? JAN *"));
+        }
+
+        [TestMethod]
+        public void TestMonthNameRange2()
+        {
+            Assert.AreEqual("At 12:23 PM, January through February", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB *"));
+        }
+
+        [TestMethod]
+        public void TestMonthNameRange3()
+        {
+            Assert.AreEqual("At 12:23 PM, January through March", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR *"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekName()
+        {
+            Assert.AreEqual("At 12:23 PM, only on Sunday", ExpressionDescriptor.GetDescription("23 12 * * SUN"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekRange()
+        {
+            Assert.AreEqual("Every 05 minutes, at 03:00 PM, Monday through Friday", ExpressionDescriptor.GetDescription("*/5 15 * * MON-FRI"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekOnceInMonth()
+        {
+            Assert.AreEqual("Every minute, on the third Monday of the month", ExpressionDescriptor.GetDescription("* * * * MON#3"));
+        }
+
+        [TestMethod]
+        public void TestLastDayOfTheWeekOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the last Thursday of the month", ExpressionDescriptor.GetDescription("* * * * 4L"));
+        }
+
+        [TestMethod]
+        public void TestLastDayOfTheMonth()
+        {
+            Assert.AreEqual("Every 05 minutes, on the last day of the month, only in January", ExpressionDescriptor.GetDescription("*/5 * L JAN *"));
+        }
+
+        [TestMethod]
+        public void TestLastWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the last weekday of the month", ExpressionDescriptor.GetDescription("* * LW * *"));
+        }
+
+        [TestMethod]
+        public void TestLastWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the last weekday of the month", ExpressionDescriptor.GetDescription("* * WL * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the first weekday of the month", ExpressionDescriptor.GetDescription("* * 1W * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the first weekday of the month", ExpressionDescriptor.GetDescription("* * W1 * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the weekday nearest day 5 of the month", ExpressionDescriptor.GetDescription("* * 5W * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the weekday nearest day 5 of the month", ExpressionDescriptor.GetDescription("* * W5 * *"));
+        }
+
+        [TestMethod]
+        public void TestTimeOfDayWithSeconds()
+        {
+            Assert.AreEqual("At 02:02:30 PM", ExpressionDescriptor.GetDescription("30 02 14 * * *"));
+        }
+
+        [TestMethod]
+        public void TestSecondInternvals()
+        {
+            Assert.AreEqual("Seconds 05 through 10 past the minute", ExpressionDescriptor.GetDescription("5-10 * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestSecondMinutesHoursIntervals()
+        {
+            Assert.AreEqual("Seconds 05 through 10 past the minute, minutes 30 through 35 past the hour, between 10:00 AM and 12:59 PM", ExpressionDescriptor.GetDescription("5-10 30-35 10-12 * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery5MinutesAt30Seconds()
+        {
+            Assert.AreEqual("At 30 seconds past the minute, every 05 minutes", ExpressionDescriptor.GetDescription("30 */5 * * * *"));
+        }
+
+        [TestMethod]
+        public void TestMinutesPastTheHourRange()
+        {
+            Assert.AreEqual("At 30 minutes past the hour, between 10:00 AM and 01:59 PM, only on Wednesday and Friday", ExpressionDescriptor.GetDescription("0 30 10-13 ? * WED,FRI"));
+        }
+
+        [TestMethod]
+        public void TestSecondsPastTheMinuteInterval()
+        {
+            Assert.AreEqual("At 10 seconds past the minute, every 05 minutes", ExpressionDescriptor.GetDescription("10 0/5 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestBetweenWithInterval()
+        {
+            Assert.AreEqual("Every 03 minutes, minutes 02 through 59 past the hour, at 01:00 AM, 09:00 AM, and 10:00 PM, between day 11 and 26 of the month, January through June", ExpressionDescriptor.GetDescription("2-59/3 1,9,22 11-26 1-6 ?"));
+        }
+
+        [TestMethod]
+        public void TestRecurringFirstOfMonth()
+        {
+            Assert.AreEqual("At 06:00 AM", ExpressionDescriptor.GetDescription("0 0 6 1/1 * ?"));
+        }
+
+        [TestMethod]
+        public void TestMinutesPastTheHour()
+        {
+            Assert.AreEqual("At 05 minutes past the hour", ExpressionDescriptor.GetDescription("0 5 0/1 * * ?"));
+        }
+
+        [TestMethod]
+        public void TestOneYearOnlyWithSeconds()
+        {
+            Assert.AreEqual("Every second, only in 2013", ExpressionDescriptor.GetDescription("* * * * * * 2013"));
+        }
+        
+        [TestMethod]
+        public void TestOneYearOnlyWithoutSeconds()
+        {
+            Assert.AreEqual("Every minute, only in 2013", ExpressionDescriptor.GetDescription("* * * * * 2013"));
+        }
+
+        [TestMethod]
+        public void TestTwoYearsOnly()
+        {
+            Assert.AreEqual("Every minute, only in 2013 and 2014", ExpressionDescriptor.GetDescription("* * * * * 2013,2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange2()
+        {
+            Assert.AreEqual("At 12:23 PM, January through February, 2013 through 2014", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB * 2013-2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange3()
+        {
+            Assert.AreEqual("At 12:23 PM, January through March, 2013 through 2015", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR * 2013-2015"));
+        }
+
+        [TestMethod]
+        public void TestHourRange()
+        {
+            Assert.AreEqual("Every 30 minutes, between 08:00 AM and 09:59 AM, on day 5 and 20 of the month", ExpressionDescriptor.GetDescription("0 0/30 8-9 5,20 * ?"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekModifier()
+        {
+            Assert.AreEqual("At 12:23 PM, on the second Sunday of the month", ExpressionDescriptor.GetDescription("23 12 * * SUN#2"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekModifierWithSundayStartOne()
+        {
+            Options options = new Options();
+            options.DayOfWeekStartIndexZero = false;
+
+            Assert.AreEqual("At 12:23 PM, on the second Sunday of the month", ExpressionDescriptor.GetDescription("23 12 * * 1#2", options));
+        }
+
+        [TestMethod]
+        public void TestHourRangeWithEveryPortion()
+        {
+            Assert.AreEqual("At 25 minutes past the hour, every 13 hours, between 07:00 AM and 07:59 PM", ExpressionDescriptor.GetDescription("0 25 7-19/13 ? * *"));
+        }
+
+        [TestMethod]
+        public void TestHourRangeWithTrailingZeroWithEveryPortion()
+        {
+            Assert.AreEqual("At 25 minutes past the hour, every 13 hours, between 07:00 AM and 08:59 PM", ExpressionDescriptor.GetDescription("0 25 7-20/13 ? * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery3Day()
+        {
+            Assert.AreEqual("At 08:00 AM, every 3 days", ExpressionDescriptor.GetDescription("0 0 8 1/3 * ? *"));
+        }
+
+        [TestMethod]
+        public void TestsEvery3DayOfTheWeek()
+        {
+            Assert.AreEqual("At 10:15 AM, every 3 days of the week", ExpressionDescriptor.GetDescription("0 15 10 ? * */3"));
+        }
+
+        [TestMethod]
+        public void TestEvery3Month()
+        {
+            Assert.AreEqual("At 07:05 AM, on day 2 of the month, every 3 months", ExpressionDescriptor.GetDescription("0 5 7 2 1/3 ? *"));
+        }
+
+        [TestMethod]
+        public void TestEvery2Years()
+        {
+            Assert.AreEqual("At 06:15 AM, on day 1 of the month, only in January, every 2 years", ExpressionDescriptor.GetDescription("0 15 6 1 1 ? 1/2"));
+        }
+
+        [TestMethod]
+        public void TestMutiPartRangeSeconds()
+        {
+            Assert.AreEqual("Minutes 2,4 through 05 past the hour, at 01:00 AM", ExpressionDescriptor.GetDescription("2,4-5 1 * * *"));
+        }
+
+        [TestMethod]
+        public void TestMutiPartRangeSeconds2()
+        {
+            Assert.AreEqual("Minutes 2,26 through 28 past the hour, at 06:00 PM", ExpressionDescriptor.GetDescription("2,26-28 18 * * *"));
+        }
+    }
+}

--- a/CronExpressionDescriptor.Net35.Test/TestFormats.cs
+++ b/CronExpressionDescriptor.Net35.Test/TestFormats.cs
@@ -1,0 +1,366 @@
+﻿using System.Globalization;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CronExpressionDescriptor.Net35.Test
+{
+    [TestClass]
+    public class TestFormats
+    {
+        [TestInitialize]
+        public void SetUp()
+        {
+            CultureInfo myCultureInfo = new CultureInfo("en-GB");
+            Thread.CurrentThread.CurrentCulture = myCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = myCultureInfo;
+        }
+
+        [TestMethod]
+        public void TestEveryMinute()
+        {
+           Assert.AreEqual("Every minute", ExpressionDescriptor.GetDescription("* * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery1Minute()
+        {
+            Assert.AreEqual("Every minute", ExpressionDescriptor.GetDescription("*/1 * * * *"));
+            Assert.AreEqual("Every minute", ExpressionDescriptor.GetDescription("0 0/1 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestEveryHour()
+        {
+            Assert.AreEqual("Every hour", ExpressionDescriptor.GetDescription("0 0 * * * ?"));
+            Assert.AreEqual("Every hour", ExpressionDescriptor.GetDescription("0 0 0/1 * * ?"));
+        }
+
+        [TestMethod]
+        public void TestTimeOfDayCertainDaysOfWeek()
+        {
+            Assert.AreEqual("At 11:00 PM, Monday through Friday", ExpressionDescriptor.GetDescription("0 23 ? * MON-FRI"));
+        }
+
+        [TestMethod]
+        public void TestEverySecond()
+        {
+            Assert.AreEqual("Every second", ExpressionDescriptor.GetDescription("* * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery45Seconds()
+        {
+            Assert.AreEqual("Every 45 seconds", ExpressionDescriptor.GetDescription("*/45 * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery5Minutes()
+        {
+            Assert.AreEqual("Every 05 minutes", ExpressionDescriptor.GetDescription("*/5 * * * *"));
+            Assert.AreEqual("Every 10 minutes", ExpressionDescriptor.GetDescription("0 0/10 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestEvery5MinutesOnTheSecond()
+        {
+            Assert.AreEqual("Every 05 minutes", ExpressionDescriptor.GetDescription("0 */5 * * * *"));
+        }
+
+        [TestMethod]
+        public void TestWeekdaysAtTime()
+        {
+            Assert.AreEqual("At 11:30 AM, Monday through Friday", ExpressionDescriptor.GetDescription("30 11 * * 1-5"));
+        }
+
+        [TestMethod]
+        public void TestDailyAtTime()
+        {
+            Assert.AreEqual("At 11:30 AM", ExpressionDescriptor.GetDescription("30 11 * * *"));
+        }
+
+        [TestMethod]
+        public void TestMinuteSpan()
+        {
+            Assert.AreEqual("Every minute between 11:00 AM and 11:10 AM", ExpressionDescriptor.GetDescription("0-10 11 * * *"));
+        }
+
+        [TestMethod]
+        public void TestOneMonthOnly()
+        {
+            Assert.AreEqual("Every minute, only in March", ExpressionDescriptor.GetDescription("* * * 3 *"));
+        }
+
+        [TestMethod]
+        public void TestTwoMonthsOnly()
+        {
+            Assert.AreEqual("Every minute, only in March and June", ExpressionDescriptor.GetDescription("* * * 3,6 *"));
+        }
+
+        [TestMethod]
+        public void TestTwoTimesEachAfternoon()
+        {
+            Assert.AreEqual("At 02:30 PM and 04:30 PM", ExpressionDescriptor.GetDescription("30 14,16 * * *"));
+        }
+
+        [TestMethod]
+        public void TestThreeTimesDaily()
+        {
+            Assert.AreEqual("At 06:30 AM, 02:30 PM and 04:30 PM", ExpressionDescriptor.GetDescription("30 6,14,16 * * *"));
+        }
+
+        [TestMethod]
+        public void TestOnceAWeek()
+        {
+            Assert.AreEqual("At 09:46 AM, only on Monday", ExpressionDescriptor.GetDescription("46 9 * * 1"));
+        }
+
+        [TestMethod]
+        public void TestDayOfMonth()
+        {
+            Assert.AreEqual("At 12:23 PM, on day 15 of the month", ExpressionDescriptor.GetDescription("23 12 15 * *"));
+        }
+
+        [TestMethod]
+        public void TestMonthName()
+        {
+            Assert.AreEqual("At 12:23 PM, only in January", ExpressionDescriptor.GetDescription("23 12 * JAN *"));
+        }
+
+        [TestMethod]
+        public void TestDayOfMonthWithQuestionMark()
+        {
+            Assert.AreEqual("At 12:23 PM, only in January", ExpressionDescriptor.GetDescription("23 12 ? JAN *"));
+        }
+
+        [TestMethod]
+        public void TestMonthNameRange2()
+        {
+            Assert.AreEqual("At 12:23 PM, January through February", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB *"));
+        }
+
+        [TestMethod]
+        public void TestMonthNameRange3()
+        {
+            Assert.AreEqual("At 12:23 PM, January through March", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR *"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekName()
+        {
+            Assert.AreEqual("At 12:23 PM, only on Sunday", ExpressionDescriptor.GetDescription("23 12 * * SUN"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekRange()
+        {
+            Assert.AreEqual("Every 05 minutes, at 03:00 PM, Monday through Friday", ExpressionDescriptor.GetDescription("*/5 15 * * MON-FRI"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekOnceInMonth()
+        {
+            Assert.AreEqual("Every minute, on the third Monday of the month", ExpressionDescriptor.GetDescription("* * * * MON#3"));
+        }
+
+        [TestMethod]
+        public void TestLastDayOfTheWeekOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the last Thursday of the month", ExpressionDescriptor.GetDescription("* * * * 4L"));
+        }
+
+        [TestMethod]
+        public void TestLastDayOfTheMonth()
+        {
+            Assert.AreEqual("Every 05 minutes, on the last day of the month, only in January", ExpressionDescriptor.GetDescription("*/5 * L JAN *"));
+        }
+
+        [TestMethod]
+        public void TestLastWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the last weekday of the month", ExpressionDescriptor.GetDescription("* * LW * *"));
+        }
+
+        [TestMethod]
+        public void TestLastWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the last weekday of the month", ExpressionDescriptor.GetDescription("* * WL * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the first weekday of the month", ExpressionDescriptor.GetDescription("* * 1W * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the first weekday of the month", ExpressionDescriptor.GetDescription("* * W1 * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("Every minute, on the weekday nearest day 5 of the month", ExpressionDescriptor.GetDescription("* * 5W * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("Every minute, on the weekday nearest day 5 of the month", ExpressionDescriptor.GetDescription("* * W5 * *"));
+        }
+
+        [TestMethod]
+        public void TestTimeOfDayWithSeconds()
+        {
+            Assert.AreEqual("At 02:02:30 PM", ExpressionDescriptor.GetDescription("30 02 14 * * *"));
+        }
+
+        [TestMethod]
+        public void TestSecondInternvals()
+        {
+            Assert.AreEqual("Seconds 05 through 10 past the minute", ExpressionDescriptor.GetDescription("5-10 * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestSecondMinutesHoursIntervals()
+        {
+            Assert.AreEqual("Seconds 05 through 10 past the minute, minutes 30 through 35 past the hour, between 10:00 AM and 12:59 PM", ExpressionDescriptor.GetDescription("5-10 30-35 10-12 * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery5MinutesAt30Seconds()
+        {
+            Assert.AreEqual("At 30 seconds past the minute, every 05 minutes", ExpressionDescriptor.GetDescription("30 */5 * * * *"));
+        }
+
+        [TestMethod]
+        public void TestMinutesPastTheHourRange()
+        {
+            Assert.AreEqual("At 30 minutes past the hour, between 10:00 AM and 01:59 PM, only on Wednesday and Friday", ExpressionDescriptor.GetDescription("0 30 10-13 ? * WED,FRI"));
+        }
+
+        [TestMethod]
+        public void TestSecondsPastTheMinuteInterval()
+        {
+            Assert.AreEqual("At 10 seconds past the minute, every 05 minutes", ExpressionDescriptor.GetDescription("10 0/5 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestBetweenWithInterval()
+        {
+            Assert.AreEqual("Every 03 minutes, minutes 02 through 59 past the hour, at 01:00 AM, 09:00 AM, and 10:00 PM, between day 11 and 26 of the month, January through June", ExpressionDescriptor.GetDescription("2-59/3 1,9,22 11-26 1-6 ?"));
+        }
+
+        [TestMethod]
+        public void TestRecurringFirstOfMonth()
+        {
+            Assert.AreEqual("At 06:00 AM", ExpressionDescriptor.GetDescription("0 0 6 1/1 * ?"));
+        }
+
+        [TestMethod]
+        public void TestMinutesPastTheHour()
+        {
+            Assert.AreEqual("At 05 minutes past the hour", ExpressionDescriptor.GetDescription("0 5 0/1 * * ?"));
+        }
+
+        [TestMethod]
+        public void TestOneYearOnlyWithSeconds()
+        {
+            Assert.AreEqual("Every second, only in 2013", ExpressionDescriptor.GetDescription("* * * * * * 2013"));
+        }
+        
+        [TestMethod]
+        public void TestOneYearOnlyWithoutSeconds()
+        {
+            Assert.AreEqual("Every minute, only in 2013", ExpressionDescriptor.GetDescription("* * * * * 2013"));
+        }
+
+        [TestMethod]
+        public void TestTwoYearsOnly()
+        {
+            Assert.AreEqual("Every minute, only in 2013 and 2014", ExpressionDescriptor.GetDescription("* * * * * 2013,2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange2()
+        {
+            Assert.AreEqual("At 12:23 PM, January through February, 2013 through 2014", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB * 2013-2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange3()
+        {
+            Assert.AreEqual("At 12:23 PM, January through March, 2013 through 2015", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR * 2013-2015"));
+        }
+
+        [TestMethod]
+        public void TestHourRange()
+        {
+            Assert.AreEqual("Every 30 minutes, between 08:00 AM and 09:59 AM, on day 5 and 20 of the month", ExpressionDescriptor.GetDescription("0 0/30 8-9 5,20 * ?"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekModifier()
+        {
+            Assert.AreEqual("At 12:23 PM, on the second Sunday of the month", ExpressionDescriptor.GetDescription("23 12 * * SUN#2"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekModifierWithSundayStartOne()
+        {
+            Options options = new Options();
+            options.DayOfWeekStartIndexZero = false;
+
+            Assert.AreEqual("At 12:23 PM, on the second Sunday of the month", ExpressionDescriptor.GetDescription("23 12 * * 1#2", options));
+        }
+
+        [TestMethod]
+        public void TestHourRangeWithEveryPortion()
+        {
+            Assert.AreEqual("At 25 minutes past the hour, every 13 hours, between 07:00 AM and 07:59 PM", ExpressionDescriptor.GetDescription("0 25 7-19/13 ? * *"));
+        }
+
+        [TestMethod]
+        public void TestHourRangeWithTrailingZeroWithEveryPortion()
+        {
+            Assert.AreEqual("At 25 minutes past the hour, every 13 hours, between 07:00 AM and 08:59 PM", ExpressionDescriptor.GetDescription("0 25 7-20/13 ? * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery3Day()
+        {
+            Assert.AreEqual("At 08:00 AM, every 3 days", ExpressionDescriptor.GetDescription("0 0 8 1/3 * ? *"));
+        }
+
+        [TestMethod]
+        public void TestsEvery3DayOfTheWeek()
+        {
+            Assert.AreEqual("At 10:15 AM, every 3 days of the week", ExpressionDescriptor.GetDescription("0 15 10 ? * */3"));
+        }
+
+        [TestMethod]
+        public void TestEvery3Month()
+        {
+            Assert.AreEqual("At 07:05 AM, on day 2 of the month, every 3 months", ExpressionDescriptor.GetDescription("0 5 7 2 1/3 ? *"));
+        }
+
+        [TestMethod]
+        public void TestEvery2Years()
+        {
+            Assert.AreEqual("At 06:15 AM, on day 1 of the month, only in January, every 2 years", ExpressionDescriptor.GetDescription("0 15 6 1 1 ? 1/2"));
+        }
+
+        [TestMethod]
+        public void TestMutiPartRangeSeconds()
+        {
+            Assert.AreEqual("Minutes 2,4 through 05 past the hour, at 01:00 AM", ExpressionDescriptor.GetDescription("2,4-5 1 * * *"));
+        }
+
+        [TestMethod]
+        public void TestMutiPartRangeSeconds2()
+        {
+            Assert.AreEqual("Minutes 2,26 through 28 past the hour, at 06:00 PM", ExpressionDescriptor.GetDescription("2,26-28 18 * * *"));
+        }
+    }
+}

--- a/CronExpressionDescriptor.Net35.Test/TestFormats.zh-cn.cs
+++ b/CronExpressionDescriptor.Net35.Test/TestFormats.zh-cn.cs
@@ -1,0 +1,329 @@
+﻿using System.Globalization;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CronExpressionDescriptor.Net35.Test
+{
+    [TestClass]
+    public class TestFormatsCN
+    {
+        [TestInitialize]
+        public void SetUp()
+        {
+            CultureInfo myCultureInfo = new CultureInfo("zh-cn");
+            Thread.CurrentThread.CurrentCulture = myCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = myCultureInfo;
+        }
+        [TestMethod]
+        public void TestEveryMinute()
+        {
+            Assert.AreEqual("每分钟", ExpressionDescriptor.GetDescription("* * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery1Minute()
+        {
+            Assert.AreEqual("每分钟", ExpressionDescriptor.GetDescription("*/1 * * * *"));
+            Assert.AreEqual("每分钟", ExpressionDescriptor.GetDescription("0 0/1 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestEveryHour()
+        {
+            Assert.AreEqual("每小时", ExpressionDescriptor.GetDescription("0 0 * * * ?"));
+            Assert.AreEqual("每小时", ExpressionDescriptor.GetDescription("0 0 0/1 * * ?"));
+        }
+
+        [TestMethod]
+        public void TestTimeOfDayCertainDaysOfWeek()
+        {
+            Assert.AreEqual("在 11:00 PM, 星期一 到 星期五", ExpressionDescriptor.GetDescription("0 23 ? * MON-FRI"));
+        }
+
+        [TestMethod]
+        public void TestEverySecond()
+        {
+            Assert.AreEqual("每秒", ExpressionDescriptor.GetDescription("* * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery45Seconds()
+        {
+            Assert.AreEqual("每 45 秒", ExpressionDescriptor.GetDescription("*/45 * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery5Minutes()
+        {
+            Assert.AreEqual("每 05 分钟", ExpressionDescriptor.GetDescription("*/5 * * * *"));
+            Assert.AreEqual("每 10 分钟", ExpressionDescriptor.GetDescription("0 0/10 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestEvery5MinutesOnTheSecond()
+        {
+            Assert.AreEqual("每 05 分钟", ExpressionDescriptor.GetDescription("0 */5 * * * *"));
+        }
+
+        [TestMethod]
+        public void TestWeekdaysAtTime()
+        {
+            Assert.AreEqual("在 11:30 AM, 星期一 到 星期五", ExpressionDescriptor.GetDescription("30 11 * * 1-5"));
+        }
+
+        [TestMethod]
+        public void TestDailyAtTime()
+        {
+            Assert.AreEqual("在 11:30 AM", ExpressionDescriptor.GetDescription("30 11 * * *"));
+        }
+
+        [TestMethod]
+        public void TestMinuteSpan()
+        {
+            Assert.AreEqual("在 11:00 AM 和 11:10 AM 之间的每分钟", ExpressionDescriptor.GetDescription("0-10 11 * * *"));
+        }
+
+        [TestMethod]
+        public void TestOneMonthOnly()
+        {
+            Assert.AreEqual("每分钟, 仅在 三月", ExpressionDescriptor.GetDescription("* * * 3 *"));
+        }
+
+        [TestMethod]
+        public void TestTwoMonthsOnly()
+        {
+            Assert.AreEqual("每分钟, 仅在 三月 和 六月", ExpressionDescriptor.GetDescription("* * * 3,6 *"));
+        }
+
+        [TestMethod]
+        public void TestTwoTimesEachAfternoon()
+        {
+            Assert.AreEqual("在 02:30 PM 和 04:30 PM", ExpressionDescriptor.GetDescription("30 14,16 * * *"));
+        }
+
+        [TestMethod]
+        public void TestThreeTimesDaily()
+        {
+            Assert.AreEqual("在 06:30 AM, 02:30 PM 和 04:30 PM", ExpressionDescriptor.GetDescription("30 6,14,16 * * *"));
+        }
+
+        [TestMethod]
+        public void TestOnceAWeek()
+        {
+            Assert.AreEqual("在 09:46 AM, 仅在 星期一", ExpressionDescriptor.GetDescription("46 9 * * 1"));
+        }
+
+        [TestMethod]
+        public void TestDayOfMonth()
+        {
+            Assert.AreEqual("在 12:23 PM, 每月的 15 号", ExpressionDescriptor.GetDescription("23 12 15 * *"));
+        }
+
+        [TestMethod]
+        public void TestMonthName()
+        {
+            Assert.AreEqual("在 12:23 PM, 仅在 一月", ExpressionDescriptor.GetDescription("23 12 * JAN *"));
+        }
+
+        [TestMethod]
+        public void TestDayOfMonthWithQuestionMark()
+        {
+            Assert.AreEqual("在 12:23 PM, 仅在 一月", ExpressionDescriptor.GetDescription("23 12 ? JAN *"));
+        }
+
+        [TestMethod]
+        public void TestMonthNameRange2()
+        {
+            Assert.AreEqual("在 12:23 PM, 一月 到 二月", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB *"));
+        }
+
+        [TestMethod]
+        public void TestMonthNameRange3()
+        {
+            Assert.AreEqual("在 12:23 PM, 一月 到 三月", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR *"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekName()
+        {
+            Assert.AreEqual("在 12:23 PM, 仅在 星期日", ExpressionDescriptor.GetDescription("23 12 * * SUN"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekRange()
+        {
+            Assert.AreEqual("每 05 分钟, 在 03:00 PM, 星期一 到 星期五", ExpressionDescriptor.GetDescription("*/5 15 * * MON-FRI"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekOnceInMonth()
+        {
+            Assert.AreEqual("每分钟, 在 第三个星期一 每月", ExpressionDescriptor.GetDescription("* * * * MON#3"));
+        }
+
+        [TestMethod]
+        public void TestLastDayOfTheWeekOfTheMonth()
+        {
+            Assert.AreEqual("每分钟, 每月的最后一个 星期四 ", ExpressionDescriptor.GetDescription("* * * * 4L"));
+        }
+
+        [TestMethod]
+        public void TestLastDayOfTheMonth()
+        {
+            Assert.AreEqual("每 05 分钟, 每月的最后一天, 仅在 一月", ExpressionDescriptor.GetDescription("*/5 * L JAN *"));
+        }
+
+        [TestMethod]
+        public void TestLastWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("每分钟, 每月的最后一个平日", ExpressionDescriptor.GetDescription("* * LW * *"));
+        }
+
+        [TestMethod]
+        public void TestLastWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("每分钟, 每月的最后一个平日", ExpressionDescriptor.GetDescription("* * WL * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("每分钟, 每月的 第一个平日 ", ExpressionDescriptor.GetDescription("* * 1W * *"));
+        }
+
+        [TestMethod]
+        public void TestFirstWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("每分钟, 每月的 第一个平日 ", ExpressionDescriptor.GetDescription("* * W1 * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth()
+        {
+            Assert.AreEqual("每分钟, 每月的 最接近 5 号的平日 ", ExpressionDescriptor.GetDescription("* * 5W * *"));
+        }
+
+        [TestMethod]
+        public void TestParticularWeekdayOfTheMonth2()
+        {
+            Assert.AreEqual("每分钟, 每月的 最接近 5 号的平日 ", ExpressionDescriptor.GetDescription("* * W5 * *"));
+        }
+
+        [TestMethod]
+        public void TestTimeOfDayWithSeconds()
+        {
+            Assert.AreEqual("在 02:02:30 PM", ExpressionDescriptor.GetDescription("30 02 14 * * *"));
+        }
+
+        [TestMethod]
+        public void TestSecondInternvals()
+        {
+            Assert.AreEqual("在每分钟的 05 到 10 秒", ExpressionDescriptor.GetDescription("5-10 * * * * *"));
+        }
+
+        [TestMethod]
+        public void TestSecondMinutesHoursIntervals()
+        {
+            Assert.AreEqual("在每分钟的 05 到 10 秒, 在每小时的 30 到 35 分钟, 在 10:00 AM 和 12:59 PM 之间", ExpressionDescriptor.GetDescription("5-10 30-35 10-12 * * *"));
+        }
+
+        [TestMethod]
+        public void TestEvery5MinutesAt30Seconds()
+        {
+            Assert.AreEqual("在每分钟的 30 秒, 每 05 分钟", ExpressionDescriptor.GetDescription("30 */5 * * * *"));
+        }
+
+        [TestMethod]
+        public void TestMinutesPastTheHourRange()
+        {
+            Assert.AreEqual("在每小时的 30 分, 在 10:00 AM 和 01:59 PM 之间, 仅在 星期三 和 星期五", ExpressionDescriptor.GetDescription("0 30 10-13 ? * WED,FRI"));
+        }
+
+        [TestMethod]
+        public void TestSecondsPastTheMinuteInterval()
+        {
+            Assert.AreEqual("在每分钟的 10 秒, 每 05 分钟", ExpressionDescriptor.GetDescription("10 0/5 * * * ?"));
+        }
+
+        [TestMethod]
+        public void TestBetweenWithInterval()
+        {
+            Assert.AreEqual("每 03 分钟, 在每小时的 02 到 59 分钟, 在 01:00 AM, 09:00 AM, 和 10:00 PM, 在每月的 11 和 26 号之间, 一月 到 六月", ExpressionDescriptor.GetDescription("2-59/3 1,9,22 11-26 1-6 ?"));
+        }
+
+        [TestMethod]
+        public void TestRecurringFirstOfMonth()
+        {
+            Assert.AreEqual("在 06:00 AM", ExpressionDescriptor.GetDescription("0 0 6 1/1 * ?"));
+        }
+
+        [TestMethod]
+        public void TestMinutesPastTheHour()
+        {
+            Assert.AreEqual("在每小时的 05 分", ExpressionDescriptor.GetDescription("0 5 0/1 * * ?"));
+        }
+
+        [TestMethod]
+        public void TestOneYearOnlyWithSeconds()
+        {
+            Assert.AreEqual("每秒, 仅在 2013", ExpressionDescriptor.GetDescription("* * * * * * 2013"));
+        }
+        
+        [TestMethod]
+        public void TestOneYearOnlyWithoutSeconds()
+        {
+            Assert.AreEqual("每分钟, 仅在 2013", ExpressionDescriptor.GetDescription("* * * * * 2013"));
+        }
+
+        [TestMethod]
+        public void TestTwoYearsOnly()
+        {
+            Assert.AreEqual("每分钟, 仅在 2013 和 2014", ExpressionDescriptor.GetDescription("* * * * * 2013,2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange2()
+        {
+            Assert.AreEqual("在 12:23 PM, 一月 到 二月, 2013 到 2014", ExpressionDescriptor.GetDescription("23 12 * JAN-FEB * 2013-2014"));
+        }
+
+        [TestMethod]
+        public void TestYearRange3()
+        {
+            Assert.AreEqual("在 12:23 PM, 一月 到 三月, 2013 到 2015", ExpressionDescriptor.GetDescription("23 12 * JAN-MAR * 2013-2015"));
+        }
+
+        [TestMethod]
+        public void TestHourRange()
+        {
+            Assert.AreEqual("每 30 分钟, 在 08:00 AM 和 09:59 AM 之间, 每月的 5 和 20 号", ExpressionDescriptor.GetDescription("0 0/30 8-9 5,20 * ?"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekModifier()
+        {
+            Assert.AreEqual("在 12:23 PM, 在 第二个星期日 每月", ExpressionDescriptor.GetDescription("23 12 * * SUN#2"));
+        }
+
+        [TestMethod]
+        public void TestDayOfWeekModifierWithSundayStartOne()
+        {
+            Options options = new Options();
+            options.DayOfWeekStartIndexZero = false;
+
+            Assert.AreEqual("在 12:23 PM, 在 第二个星期日 每月", ExpressionDescriptor.GetDescription("23 12 * * 1#2", options));
+        }
+
+        [TestMethod]
+        public void TestHourRangeWithEveryPortion()
+        {
+            Assert.AreEqual("在每小时的 25 分, 每 13 小时, 在 07:00 AM 和 07:59 PM 之间", ExpressionDescriptor.GetDescription("0 25 7-19/13 ? * *"));
+        }
+
+        [TestMethod]
+        public void TestHourRangeWithTrailingZeroWithEveryPortion()
+        {
+            Assert.AreEqual("在每小时的 25 分, 每 13 小时, 在 07:00 AM 和 08:59 PM 之间", ExpressionDescriptor.GetDescription("0 25 7-20/13 ? * *"));
+        }
+    }
+}

--- a/CronExpressionDescriptor.sln
+++ b/CronExpressionDescriptor.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30501.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EBD2EEF7-FE3F-4627-8931-BACA70D80B03}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
@@ -12,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CronExpressionDescriptor", "CronExpressionDescriptor\CronExpressionDescriptor.csproj", "{BD023841-603A-4B09-A3B1-522664C1E274}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CronExpressionDescriptor.Net35.Test", "CronExpressionDescriptor.Net35.Test\CronExpressionDescriptor.Net35.Test.csproj", "{EC37F6BE-96D0-434D-AC1A-075C8ADC022D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CronExpressionDescriptor.Test", "CronExpressionDescriptor.Test\CronExpressionDescriptor.Test.csproj", "{8544E66A-B914-4A85-BF14-5E320015299F}"
 EndProject
@@ -25,6 +29,10 @@ Global
 		{BD023841-603A-4B09-A3B1-522664C1E274}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BD023841-603A-4B09-A3B1-522664C1E274}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BD023841-603A-4B09-A3B1-522664C1E274}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC37F6BE-96D0-434D-AC1A-075C8ADC022D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC37F6BE-96D0-434D-AC1A-075C8ADC022D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC37F6BE-96D0-434D-AC1A-075C8ADC022D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC37F6BE-96D0-434D-AC1A-075C8ADC022D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8544E66A-B914-4A85-BF14-5E320015299F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8544E66A-B914-4A85-BF14-5E320015299F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8544E66A-B914-4A85-BF14-5E320015299F}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/CronExpressionDescriptor/ExpressionParser.cs
+++ b/CronExpressionDescriptor/ExpressionParser.cs
@@ -21,11 +21,19 @@ namespace CronExpressionDescriptor
         /// </summary>
         /// <param name="expression">The cron expression string</param>
         /// <param name="options">Parsing options</param>
-        public ExpressionParser(string expression, Options options)
+        public ExpressionParser(string expression, Options options) : this(expression, options, new CultureInfo("en-GB")) { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <param name="options"></param>
+        /// <param name="culture">allows setting of en-GB</param>
+        public ExpressionParser(string expression, Options options, CultureInfo culture)
         {
             m_expression = expression;
             m_options = options;
-            m_en_culture = new CultureInfo("en"); //Default to English
+            m_en_culture = culture;
         }
 
         /// <summary>
@@ -162,7 +170,7 @@ namespace CronExpressionDescriptor
             for (int i = 1; i <= 12; i++)
             {
                 DateTime currentMonth = new DateTime(DateTime.Now.Year, i, 1);
-                string currentMonthDescription = currentMonth.ToString("MMM", m_en_culture).ToUpperInvariant();
+                string currentMonthDescription = currentMonth.ToString("MMM", m_en_culture).ToUpperInvariant(); //broken here
                 expressionParts[4] = expressionParts[4].Replace(currentMonthDescription, i.ToString());
             }
 


### PR DESCRIPTION
Although the package is published and available via nuget for .net 3.5 consumers, it is actually unusable because the .net35 framework does not recognise language neutral cultures.

there is one line of code that defaults to a language neutral english that is causing a bit of a problem, correcting that will ensure that the library works with older .net framework.

also copied over the tests with a new project built on .net 35 to prove that is hasn't broken .net 4 and now works with .net 35