### PR TITLE
A crude fix for Issue #44.

### DIFF
--- a/CronExpressionDescriptor.Test/TestExceptions.cs
+++ b/CronExpressionDescriptor.Test/TestExceptions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Globalization;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 
 namespace CronExpressionDescriptor.Test
@@ -9,6 +11,14 @@ namespace CronExpressionDescriptor.Test
     [TestFixture]
     public class TestExceptions
     {
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            CultureInfo myCultureInfo = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = myCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = myCultureInfo;
+        }
+
         [Test]
         [ExpectedException(typeof(MissingFieldException))]
         public void TestNullCronExpressionException()

--- a/CronExpressionDescriptor.Test/TestFormats.cs
+++ b/CronExpressionDescriptor.Test/TestFormats.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using System.Globalization;
 using System.Threading;
 
@@ -13,6 +14,12 @@ namespace CronExpressionDescriptor.Test
             CultureInfo myCultureInfo = new CultureInfo("en-US");
             Thread.CurrentThread.CurrentCulture = myCultureInfo;
             Thread.CurrentThread.CurrentUICulture = myCultureInfo;
+        }
+
+        [Test]
+        public void TestIssue44()
+        {
+            Assert.AreEqual("At 10:00 AM, Monday through Thursday, Sunday", ExpressionDescriptor.GetDescription("0 00 10 ? * MON-THU,SUN *"));
         }
 
         [Test]


### PR DESCRIPTION
The changes in this PR attempt to fix [Issue #44](https://github.com/bradyholt/cron-expression-descriptor/issues/44).

Understanding the code better, there might be better solutions to do this, but this is what worked for me until someone else comes up with something better.

Also included a fix in TestExceptions.cs, otherwise the tests will always fail on a German Windows installation.

Note that for me all the "TestFormatsUk" tests fail, with issues like this:

```
 Test 'CronExpressionDescriptor.Test.TestFormatsUk.TestYearRange3' failed: 
   String lengths are both 41. Strings differ at index 9.
   Expected: "О 12:23, Січень по Березень, 2013 по 2015"
   But was:  "О 12:23, січень по березень, 2013 по 2015"
   --------------------^
 	TestFormats.uk.cs(309,0): at CronExpressionDescriptor.Test.TestFormatsUk.TestYearRange3()
```

Hence always the casing of the `c` in all messages. Might be some local issue on my box, I don't know.

Please feel free to reject this PR if it doesn't suit or fit. I just thought I put it up here, if someone else needs it. :-)

