### PR TITLE
Remove empty entries when parsing a CRON expression

### DIFF
--- a/CronExpressionDescriptor.Test/TestFormats.cs
+++ b/CronExpressionDescriptor.Test/TestFormats.cs
@@ -368,5 +368,12 @@ namespace CronExpressionDescriptor.Test
         {
             Assert.AreEqual("Minutes 2,26 through 28 past the hour, at 06:00 PM", ExpressionDescriptor.GetDescription("2,26-28 18 * * *"));
         }
+
+        [Test]
+        public void TrailingSpaceDoesNotCauseAWrongDescription()
+        {
+            // GitHub Issue #51: https://github.com/bradyholt/cron-expression-descriptor/issues/51
+            Assert.AreEqual("At 07:00 AM", ExpressionDescriptor.GetDescription("0 7 * * * "));
+        }
     }
 }

--- a/CronExpressionDescriptor/ExpressionParser.cs
+++ b/CronExpressionDescriptor/ExpressionParser.cs
@@ -43,7 +43,7 @@ namespace CronExpressionDescriptor
             }
             else
             {
-                string[] expressionPartsTemp = m_expression.Split(' ');
+                string[] expressionPartsTemp = m_expression.Split(new [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
                 if (expressionPartsTemp.Length < 5)
                 {


### PR DESCRIPTION
Trailing space caused a wrong description, when 5-part expression is passed. Due to an empty part, expression parser treated this expression as a 6-part one.

Fixes #51.