### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ packages
 testrunner
 TestResult.xml
 applicationhost.config
+CronExpressionDescriptor/Resources.ro.Designer.cs

--- a/CronExpressionDescriptor.Test/CronExpressionDescriptor.Test.csproj
+++ b/CronExpressionDescriptor.Test/CronExpressionDescriptor.Test.csproj
@@ -87,6 +87,7 @@
     <Compile Include="TestFormats.nl.cs" />
     <Compile Include="TestFormats.no.cs" />
     <Compile Include="TestFormats.pt-br.cs" />
+    <Compile Include="TestFormats.ro.cs" />
     <Compile Include="TestFormats.ru.cs" />
     <Compile Include="TestFormats.tr.cs" />
     <Compile Include="TestFormats.uk.cs" />

--- a/CronExpressionDescriptor.Test/TestFormats.ro.cs
+++ b/CronExpressionDescriptor.Test/TestFormats.ro.cs
@@ -1,0 +1,489 @@
+﻿namespace CronExpressionDescriptor.Test
+{
+    using NUnit.Framework;
+    using System.Globalization;
+    using System.Threading;
+
+    /// <summary>
+    /// Tests for Romanian language
+    /// </summary>
+    [TestFixture]
+    public class TestFormatsRO
+    {
+        static readonly Options _verbose = new Options() { Verbose = true };
+
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            CultureInfo myCultureInfo = new CultureInfo("ro-RO");
+            Thread.CurrentThread.CurrentCulture = myCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = myCultureInfo;
+        }
+
+        void Harness (string cron, string expected, string expectedVerbose)
+        {
+            Assert.AreEqual(expected, ExpressionDescriptor.GetDescription(cron));
+            Assert.AreEqual(expectedVerbose, ExpressionDescriptor.GetDescription(cron, _verbose));
+        }
+
+        [Test]
+        public void TestEveryMinute()
+        {
+            Harness (cron: "* * * * *", 
+                expected: "În fiecare minut", 
+                expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestEvery1Minute()
+        {
+            Harness(cron: "*/1 * * * *"  , expected: "În fiecare minut", expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi");
+            Harness(cron: "0 0/1 * * * ?", expected: "În fiecare minut", expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi");            
+        }
+
+        [Test]
+        public void TestEveryHour()
+        {
+            Harness(cron: "0 0 * * * ?", expected: "În fiecare oră", expectedVerbose: "În fiecare oră, în fiecare zi");
+            Harness(cron: "0 0 0/1 * * ?", expected: "În fiecare oră", expectedVerbose: "În fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestTimeOfDayCertainDaysOfWeek()
+        {
+           Harness(cron: "0 23 ? * MON-FRI", expected: "La 23:00, de luni până vineri"
+               , expectedVerbose: "La 11:00 PM, de luni până vineri");            
+        }
+
+        [Test]
+        public void TestEverySecond()
+        {
+            Harness(cron: "* * * * * *", expected: "În fiecare secundă"
+                , expectedVerbose: "În fiecare secundă, în fiecare minut, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestEvery45Seconds()
+        {
+            Harness(cron: "*/45 * * * * *",
+                expected: "La fiecare 45 secunde", 
+                expectedVerbose: "La fiecare 45 secunde, în fiecare minut, în fiecare oră, în fiecare zi"); 
+        }
+
+        [Test]
+        public void TestEvery5Minutes()
+        {
+            Harness(cron: "*/5 * * * *",
+                expected: "La fiecare 05 minute",
+                expectedVerbose: "La fiecare 05 minute, în fiecare oră, în fiecare zi");
+
+            Harness(cron: "0 0/10 * * * ?",
+                expected: "La fiecare 10 minute",
+                expectedVerbose: "La fiecare 10 minute, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestEvery5MinutesOnTheSecond()
+        {
+            Harness(cron: "0 */5 * * * *", expected: "La fiecare 05 minute", 
+                expectedVerbose: "La fiecare 05 minute, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestWeekdaysAtTime()
+        {
+            Harness (cron:"30 11 * * 1-5", 
+                expected:  "La 11:30, de luni până vineri",
+                expectedVerbose:  "La 11:30 AM, de luni până vineri");
+        }
+
+        [Test]
+        public void TestDailyAtTime()
+        {
+            Harness(cron: "30 11 * * *", expected: "La 11:30", expectedVerbose: "La 11:30 AM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestMinuteSpan()
+        {
+            Harness("0-10 11 * * *", expected: "În fiecare minut între 11:00 și 11:10",
+                expectedVerbose: "În fiecare minut între 11:00 AM și 11:10 AM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestOneMonthOnly()
+        {
+            Harness (cron:"* * * 3 *", expected:"În fiecare minut, doar în martie", 
+                expectedVerbose:"În fiecare minut, în fiecare oră, în fiecare zi, doar în martie");
+        }
+
+        [Test]
+        public void TestTwoMonthsOnly()
+        {
+            Harness ( cron:"* * * 3,6 *",
+                expected: "În fiecare minut, doar în martie și iunie",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi, doar în martie și iunie");
+        }
+
+        [Test]
+        public void TestTwoTimesEachAfternoon()
+        {
+            Harness(cron: "30 14,16 * * *", expected: "La 14:30 și 16:30",
+                expectedVerbose: "La 02:30 PM și 04:30 PM, în fiecare zi");  
+        }
+
+        [Test]
+        public void TestThreeTimesDaily()
+        {
+            Harness(cron:"30 6,14,16 * * *",
+                expected:"La 06:30, 14:30 și 16:30",
+                expectedVerbose: "La 06:30 AM, 02:30 PM și 04:30 PM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestOnceAWeek()
+        {
+            Harness(cron: "46 9 * * 1", expected: "La 09:46, doar luni", expectedVerbose: "La 09:46 AM, doar luni");
+        }
+
+        [Test]
+        public void TestDayOfMonth()
+        {
+            Harness(cron: "23 12 15 * *", 
+                expected: "La 12:23, în ziua 15 a lunii", 
+                expectedVerbose: "La 12:23 PM, în ziua 15 a lunii");
+        }
+
+        [Test]
+        public void TestMonthName()
+        {
+            Harness(cron: "23 12 * JAN *", expected: "La 12:23, doar în ianuarie",
+                expectedVerbose: "La 12:23 PM, în fiecare zi, doar în ianuarie");
+        }
+
+        [Test]
+        public void TestDayOfMonthWithQuestionMark()
+        {
+            Harness(cron: "23 12 ? JAN *", expected: "La 12:23, doar în ianuarie", expectedVerbose: "La 12:23 PM, în fiecare zi, doar în ianuarie");
+        }
+
+        [Test]
+        public void TestMonthNameRange2()
+        {
+            Harness(cron:"23 12 * JAN-FEB *",
+                expected: "La 12:23, din ianuarie până în februarie",
+                expectedVerbose: "La 12:23 PM, în fiecare zi, din ianuarie până în februarie");
+        }
+
+        [Test]
+        public void TestMonthNameRange3()
+        {
+            Harness(cron: "23 12 * JAN-MAR *", expected: "La 12:23, din ianuarie până în martie",
+                expectedVerbose: "La 12:23 PM, în fiecare zi, din ianuarie până în martie");
+        }
+
+        [Test]
+        public void TestDayOfWeekName()
+        {
+            Harness(cron: "23 12 * * SUN", expected: "La 12:23, doar duminică", expectedVerbose: "La 12:23 PM, doar duminică");
+        }
+
+        [Test]
+        public void TestDayOfWeekRange()
+        {
+            Harness(cron: "*/5 15 * * MON-FRI", 
+                expected: "La fiecare 05 minute, la 15:00, de luni până vineri",
+                expectedVerbose: "La fiecare 05 minute, la 03:00 PM, de luni până vineri");
+        }
+
+        [Test]
+        public void TestDayOfWeekOnceInMonth()
+        {
+            Harness(cron: "* * * * MON#3", 
+                expected: "În fiecare minut, în a treia luni a lunii", 
+                expectedVerbose: "În fiecare minut, în fiecare oră, în a treia luni a lunii");
+        }
+
+        [Test]
+        public void TestLastDayOfTheWeekOfTheMonth()
+        {
+            Harness(cron: "* * * * 4L", 
+                expected: "În fiecare minut, în ultima joi a lunii",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în ultima joi a lunii");
+        }
+
+        [Test]
+        public void TestLastDayOfTheMonth()
+        {
+            Harness(cron: "*/5 * L JAN *", expected: "La fiecare 05 minute, în ultima zi a lunii, doar în ianuarie",
+                expectedVerbose: "La fiecare 05 minute, în fiecare oră, în ultima zi a lunii, doar în ianuarie");
+        }
+
+        [Test]
+        public void TestLastWeekdayOfTheMonth()
+        {
+            Harness(cron: "* * LW * *", 
+                expected: "În fiecare minut, în ultima zi lucrătoare a lunii",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în ultima zi lucrătoare a lunii");
+        }
+
+        [Test]
+        public void TestLastWeekdayOfTheMonth2()
+        {
+            Harness(cron: "* * WL * *",
+                expected: "În fiecare minut, în ultima zi lucrătoare a lunii",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în ultima zi lucrătoare a lunii");
+        }
+
+        [Test]
+        public void TestFirstWeekdayOfTheMonth()
+        {
+            Harness(cron: "* * 1W * *", expected: "În fiecare minut, în prima zi a săptămânii a lunii"
+                , expectedVerbose: "În fiecare minut, în fiecare oră, în prima zi a săptămânii a lunii");
+           }
+
+        [Test]
+        public void TestThirteenthWeekdayOfTheMonth()
+        {
+            Harness(cron: "* * 13W * *", 
+                expected: "În fiecare minut, în cea mai apropiată zi a săptămânii de ziua 13 a lunii",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în cea mai apropiată zi a săptămânii de ziua 13 a lunii");
+        }
+
+        [Test]
+        public void TestFirstWeekdayOfTheMonth2()
+        {
+            Harness(cron: "* * W1 * *", expected: "În fiecare minut, în prima zi a săptămânii a lunii"
+               , expectedVerbose: "În fiecare minut, în fiecare oră, în prima zi a săptămânii a lunii");
+        }
+
+        [Test]
+        public void TestParticularWeekdayOfTheMonth()
+        {
+            Harness(cron: "* * 5W * *",
+                expected: "În fiecare minut, în cea mai apropiată zi a săptămânii de ziua 5 a lunii", 
+                expectedVerbose: "În fiecare minut, în fiecare oră, în cea mai apropiată zi a săptămânii de ziua 5 a lunii");
+        }
+
+        [Test]
+        public void TestParticularWeekdayOfTheMonth2()
+        {
+            Harness(cron: "* * W5 * *",
+                expected: "În fiecare minut, în cea mai apropiată zi a săptămânii de ziua 5 a lunii",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în cea mai apropiată zi a săptămânii de ziua 5 a lunii");
+        }
+
+        [Test]
+        public void TestTimeOfDayWithSeconds()
+        {
+            Harness(cron: "30 02 14 * * *",
+                expected: "La 14:02:30",
+                expectedVerbose: "La 02:02:30 PM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestSecondInternvals()
+        {
+            Harness(cron: "5-10 * * * * *", 
+                expected: "Între secunda 05 și secunda 10",
+                expectedVerbose: "Între secunda 05 și secunda 10, în fiecare minut, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestSecondMinutesHoursIntervals()
+        {
+            Harness(cron: "5-10 30-35 10-12 * * *",
+                expected: "Între secunda 05 și secunda 10, între minutele 30 și 35, între 10:00 și 12:59",
+                expectedVerbose: "Între secunda 05 și secunda 10, între minutele 30 și 35, între 10:00 AM și 12:59 PM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestEvery5MinutesAt30Seconds()
+        {
+            Harness(cron: "30 */5 * * * *",
+                expected: "La și 30 de secunde, la fiecare 05 minute",
+                expectedVerbose: "La și 30 de secunde, la fiecare 05 minute, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestMinutesPastTheHourRange()
+        {
+            Harness(cron: "0 30 10-13 ? * WED,FRI", 
+                expected: "La și 30 de minute, între 10:00 și 13:59, doar miercuri și vineri",
+                expectedVerbose: "La și 30 de minute, între 10:00 AM și 01:59 PM, doar miercuri și vineri");            
+        }
+
+        [Test]
+        public void TestSecondsPastTheMinuteInterval()
+        {
+            Harness (cron:"10 0/5 * * * ?", 
+                expected: "La și 10 secunde, la fiecare 05 minute",
+                expectedVerbose: "La și 10 secunde, la fiecare 05 minute, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestBetweenWithInterval()
+        {
+           //"Every 03 minutes, minutes 02 through 59 past the hour, at 01:00 AM, 09:00 AM, and 10:00 PM, between day 11 and 26 of the month, January through June"
+            Harness( cron: "2-59/3 1,9,22 11-26 1-6 ?",
+                expected: "La fiecare 03 minute, între minutele 02 și 59, la 01:00, 09:00, și 22:00, între zilele 11 și 26 ale lunii, din ianuarie până în iunie", 
+                expectedVerbose: "La fiecare 03 minute, între minutele 02 și 59, la 01:00 AM, 09:00 AM, și 10:00 PM, între zilele 11 și 26 ale lunii, din ianuarie până în iunie");
+        }
+
+        [Test]
+        public void TestRecurringFirstOfMonth()
+        {
+            Harness(cron: "0 0 6 1/1 * ?", expected: "La 06:00", expectedVerbose: "La 06:00 AM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestMinutesPastTheHour()
+        {
+            Harness (cron:"0 5 0/1 * * ?", 
+                expected: "La și 05 minute",
+                expectedVerbose: "La și 05 minute, în fiecare oră, în fiecare zi");
+        }
+
+        [Test]
+        public void TestOneYearOnlyWithSeconds()
+        {
+            Harness(cron: "* * * * * * 2013", expected: "În fiecare secundă, doar în 2013",
+                expectedVerbose: "În fiecare secundă, în fiecare minut, în fiecare oră, în fiecare zi, doar în 2013");
+        }
+
+        [Test]
+        public void TestOneYearOnlyWithoutSeconds()
+        {
+            Harness(cron:"* * * * * 2013", expected:"În fiecare minut, doar în 2013",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi, doar în 2013");
+        }
+
+        [Test]
+        public void TestTwoYearsOnly()
+        {
+            Harness (cron:"* * * * * 2013,2014",
+                expected: "În fiecare minut, doar în 2013 și 2014",
+                expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi, doar în 2013 și 2014");
+        }
+
+        [Test]
+        public void TestYearRange2()
+        {
+            Harness (cron:"23 12 * JAN-FEB * 2013-2014",
+                expected:"La 12:23, din ianuarie până în februarie, din 2013 până în 2014",
+                expectedVerbose:"La 12:23 PM, în fiecare zi, din ianuarie până în februarie, din 2013 până în 2014");
+        }
+
+        [Test]
+        public void TestYearRange3()
+        {
+            Harness (cron:"23 12 * JAN-MAR * 2013-2015",
+                expected: "La 12:23, din ianuarie până în martie, din 2013 până în 2015",
+                expectedVerbose: "La 12:23 PM, în fiecare zi, din ianuarie până în martie, din 2013 până în 2015");
+        }
+
+        [Test]
+        public void TestHourRange()
+        {
+            Harness(cron: "0 0/30 8-9 5,20 * ?",
+                expected: "La fiecare 30 minute, între 08:00 și 09:59, în ziua 5 și 20 a lunii",
+                expectedVerbose: "La fiecare 30 minute, între 08:00 AM și 09:59 AM, în ziua 5 și 20 a lunii");
+        }
+
+        [Test]
+        public void TestDayOfWeekModifier()
+        {
+            Harness(cron: "23 12 * * SUN#2", 
+                expected: "La 12:23, în a doua duminică a lunii", 
+                expectedVerbose: "La 12:23 PM, în a doua duminică a lunii");
+        }
+
+        [Test]
+        public void TestDayOfWeekModifierWithSundayStartOne()
+        {
+            Assert.AreEqual("La 12:23, în a doua duminică a lunii",
+                ExpressionDescriptor.GetDescription("23 12 * * 1#2", 
+                    new Options() { DayOfWeekStartIndexZero = false }));
+        }
+
+        [Test]
+        public void TestHourRangeWithEveryPortion()
+        {
+            Harness(cron: "0 25 7-19/13 ? * *", 
+                expected: "La și 25 de minute, la fiecare 13 ore, între 07:00 și 19:59",
+                expectedVerbose: "La și 25 de minute, la fiecare 13 ore, între 07:00 AM și 07:59 PM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestHourRangeWithTrailingZeroWithEveryPortion()
+        {
+            Harness(cron: "0 25 7-20/13 ? * *",
+               expected: "La și 25 de minute, la fiecare 13 ore, între 07:00 și 20:59",
+               expectedVerbose: "La și 25 de minute, la fiecare 13 ore, între 07:00 AM și 08:59 PM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestEvery3Day()
+        {
+            Harness(cron: "0 0 8 1/3 * ? *", 
+                expected: "La 08:00, la fiecare 3 zile",
+                expectedVerbose: "La 08:00 AM, la fiecare 3 zile");
+        }
+
+        [Test]
+        public void TestsEvery3DayOfTheWeek()
+        {
+            Harness(cron: "0 15 10 ? * */3",
+                expected: "La 10:15, la fiecare a 3-a zi a săptămânii",
+                expectedVerbose: "La 10:15 AM, la fiecare a 3-a zi a săptămânii");
+        }
+
+        [Test]
+        public void TestEvery3Month()
+        {
+            Harness(cron: "0 5 7 2 1/3 ? *", 
+                expected: "La 07:05, în ziua 2 a lunii, la fiecare 3 luni",
+                expectedVerbose: "La 07:05 AM, în ziua 2 a lunii, la fiecare 3 luni");
+        }
+
+        [Test]
+        public void TestEvery2Years()
+        {
+            Harness(cron: "0 15 6 1 1 ? 1/2",
+                expected: "La 06:15, în ziua 1 a lunii, doar în ianuarie, o dată la 2 ani",
+                expectedVerbose: "La 06:15 AM, în ziua 1 a lunii, doar în ianuarie, o dată la 2 ani");
+        }
+
+        [Test]
+        public void TestMutiPartRangeSeconds()
+        {
+            Harness (cron:"2,4-5 1 * * *",
+                expected: "La și 02 și de la 04 până la 05 minute, la 01:00",
+                expectedVerbose: "La și 02 și de la 04 până la 05 minute, la 01:00 AM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestMutiPartRangeSeconds2()
+        {
+            Harness(cron: "2,26-28 18 * * *",
+                expected: "La și 02 și de la 26 până la 28 minute, la 18:00",
+                expectedVerbose: "La și 02 și de la 26 până la 28 minute, la 06:00 PM, în fiecare zi");            
+        }
+
+        [Test]
+        public void TrailingSpaceDoesNotCauseAWrongDescription()
+        {
+            // GitHub Issue #51: https://github.com/bradyholt/cron-expression-descriptor/issues/51
+            Harness(cron: "0 7 * * * ", expected: "La 07:00", expectedVerbose: "La 07:00 AM, în fiecare zi");
+        }
+
+        [Test]
+        public void TestMultiPartDayOfTheWeek()
+        {
+            // GitHub Issue #44: https://github.com/bradyholt/cron-expression-descriptor/issues/44
+            Harness (cron:"0 00 10 ? * MON-THU,SUN *",
+                expected: "La 10:00, doar de luni până joi și duminică",
+                expectedVerbose: "La 10:00 AM, doar de luni până joi și duminică");
+        }
+    }
+}

--- a/CronExpressionDescriptor/CronExpressionDescriptor.csproj
+++ b/CronExpressionDescriptor/CronExpressionDescriptor.csproj
@@ -90,6 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources.it.resx" />
+    <EmbeddedResource Include="Resources.ro.resx" />      
     <EmbeddedResource Include="Resources.uk.resx" />
     <EmbeddedResource Include="Resources.de.resx">
       <SubType>Designer</SubType>

--- a/CronExpressionDescriptor/ExpressionDescriptor.cs
+++ b/CronExpressionDescriptor/ExpressionDescriptor.cs
@@ -235,7 +235,12 @@ namespace CronExpressionDescriptor
                (s => s.PadLeft(2, '0')),
                (s => string.Format(CronExpressionDescriptor.Resources.EveryX0Seconds, s)),
                (s => CronExpressionDescriptor.Resources.SecondsX0ThroughX1PastTheMinute),
-               (s => CronExpressionDescriptor.Resources.AtX0SecondsPastTheMinute));
+               (s => s == "0" 
+                    ? string.Empty 
+                    : (int.Parse(s) < 20)
+                        ? CronExpressionDescriptor.Resources.AtX0SecondsPastTheMinute
+                        : CronExpressionDescriptor.Resources.AtX0SecondsPastTheMinuteGt20 ?? CronExpressionDescriptor.Resources.AtX0SecondsPastTheMinute
+               ));
 
             return description;
         }
@@ -247,11 +252,18 @@ namespace CronExpressionDescriptor
         protected string GetMinutesDescription()
         {
             string description = GetSegmentDescription(m_expressionParts[1],
-                  CronExpressionDescriptor.Resources.EveryMinute,
+                CronExpressionDescriptor.Resources.EveryMinute,
                 (s => s.PadLeft(2, '0')),
                 (s => string.Format(CronExpressionDescriptor.Resources.EveryX0Minutes, s.PadLeft(2, '0'))),
                 (s => CronExpressionDescriptor.Resources.MinutesX0ThroughX1PastTheHour),
-                (s => s == "0" ? string.Empty : CronExpressionDescriptor.Resources.AtX0MinutesPastTheHour));
+                (s => { try {
+                          return s == "0" 
+                            ? string.Empty 
+                            : (int.Parse(s) < 20)
+                                ? CronExpressionDescriptor.Resources.AtX0MinutesPastTheHour
+                                : CronExpressionDescriptor.Resources.AtX0MinutesPastTheHourGt20 ?? CronExpressionDescriptor.Resources.AtX0MinutesPastTheHour;}
+                        catch { return CronExpressionDescriptor.Resources.AtX0MinutesPastTheHour; }} ),
+                CronExpressionDescriptor.Resources.ComaMinX0ThroughMinX1 );
 
             return description;
         }
@@ -352,7 +364,7 @@ namespace CronExpressionDescriptor
                 string.Empty,
                (s => new DateTime(DateTime.Now.Year, Convert.ToInt32(s), 1).ToString("MMMM")),
                (s => string.Format(CronExpressionDescriptor.Resources.ComaEveryX0Months, s)),
-               (s => CronExpressionDescriptor.Resources.ComaX0ThroughX1),
+               (s => CronExpressionDescriptor.Resources.ComaMonthX0ThroughMonthX1 ?? CronExpressionDescriptor.Resources.ComaX0ThroughX1),
                (s => CronExpressionDescriptor.Resources.ComaOnlyInX0));
 
             return description;
@@ -416,7 +428,7 @@ namespace CronExpressionDescriptor
                 string.Empty,
                (s => new DateTime(Convert.ToInt32(s), 1, 1).ToString("yyyy")),
                (s => string.Format(CronExpressionDescriptor.Resources.ComaEveryX0Years, s)),
-               (s => CronExpressionDescriptor.Resources.ComaX0ThroughX1),
+               (s =>  CronExpressionDescriptor.Resources.ComaYearX0ThroughYearX1 ?? CronExpressionDescriptor.Resources.ComaX0ThroughX1),
                (s => CronExpressionDescriptor.Resources.ComaOnlyInX0));
 
             return description;
@@ -437,7 +449,9 @@ namespace CronExpressionDescriptor
             Func<string, string> getSingleItemDescription,
             Func<string, string> getIntervalDescriptionFormat,
             Func<string, string> getBetweenDescriptionFormat,
-            Func<string, string> getDescriptionFormat)
+            Func<string, string> getDescriptionFormat,
+            string multiPartRangeFormat = null
+            )
         {
             string description = null;
 
@@ -497,7 +511,7 @@ namespace CronExpressionDescriptor
                         string betweenSegment1Description = getSingleItemDescription(betweenSegments[0]);
                         string betweenSegment2Description = getSingleItemDescription(betweenSegments[1]);
                         betweenSegment2Description = betweenSegment2Description.Replace(":00", ":59");
-                        var betweenDescription = string.Format(CronExpressionDescriptor.Resources.ComaX0ThroughX1, betweenSegment1Description, betweenSegment2Description);
+                        var betweenDescription = string.Format(multiPartRangeFormat ?? CronExpressionDescriptor.Resources.ComaX0ThroughX1, betweenSegment1Description, betweenSegment2Description);
                         
                         //remove leading comma
                         betweenDescription = betweenDescription.Replace(", ", "");

--- a/CronExpressionDescriptor/Options.cs
+++ b/CronExpressionDescriptor/Options.cs
@@ -23,6 +23,7 @@ namespace CronExpressionDescriptor
                 || cultureInfo.Equals(new CultureInfo("de-DE")) //German
                 || cultureInfo.Equals(new CultureInfo("it-IT")) //Italian
                 || cultureInfo.Equals(new CultureInfo("tr-TR")) //Turkish
+                || cultureInfo.Equals(new CultureInfo("ro-RO")) //Romanian                
                 )
             {
                 this.Use24HourTimeFormat = true;

--- a/CronExpressionDescriptor/Resources.Designer.cs
+++ b/CronExpressionDescriptor/Resources.Designer.cs
@@ -99,11 +99,12 @@ namespace CronExpressionDescriptor {
         /// <summary>
         ///   Looks up a localized string similar to at {0} minutes past the hour.
         /// </summary>
-        internal static string AtX0MinutesPastTheHour {
+        internal static string AtX0MinutesPastTheHour { 
             get {
                 return ResourceManager.GetString("AtX0MinutesPastTheHour", resourceCulture);
             }
         }
+        internal static string AtX0MinutesPastTheHourGt20 { get { return ResourceManager.GetString("AtX0MinutesPastTheHourGt20", resourceCulture); } }
         
         /// <summary>
         ///   Looks up a localized string similar to at {0} seconds past the minute.
@@ -113,7 +114,8 @@ namespace CronExpressionDescriptor {
                 return ResourceManager.GetString("AtX0SecondsPastTheMinute", resourceCulture);
             }
         }
-        
+        internal static string AtX0SecondsPastTheMinuteGt20 { get { return ResourceManager.GetString("AtX0SecondsPastTheMinuteGt20", resourceCulture); } }
+
         /// <summary>
         ///   Looks up a localized string similar to between {0} and {1}.
         /// </summary>
@@ -275,7 +277,16 @@ namespace CronExpressionDescriptor {
                 return ResourceManager.GetString("ComaX0ThroughX1", resourceCulture);
             }
         }
-        
+
+        /// <summary> Looks up a localized string similar to: from minute {0} through minute {1}. </summary>
+        internal static string ComaMinX0ThroughMinX1 { get { return ResourceManager.GetString("ComaMinX0ThroughMinX1", resourceCulture); } }
+
+        /// <summary> Looks up a localized string similar to: from minute {0} through minute {1}. </summary>
+        internal static string ComaMonthX0ThroughMonthX1 { get { return ResourceManager.GetString("ComaMonthX0ThroughMonthX1", resourceCulture); } }
+
+        /// <summary> Looks up a localized string similar to: from minute {0} through minute {1}. </summary>
+        internal static string ComaYearX0ThroughYearX1 { get { return ResourceManager.GetString("ComaYearX0ThroughYearX1", resourceCulture); } }
+
         /// <summary>
         ///   Looks up a localized string similar to every hour.
         /// </summary>

--- a/CronExpressionDescriptor/Resources.ro.resx
+++ b/CronExpressionDescriptor/Resources.ro.resx
@@ -1,0 +1,311 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AnErrorOccuredWhenGeneratingTheExpressionD" xml:space="preserve">
+    <value>Eroare la generarea descrierii. Verificați sintaxa.</value>
+    <comment>AnErrorOccuredWhenGeneratingTheExpressionD description</comment>
+  </data>
+  <data name="At" xml:space="preserve">
+    <value>La</value>
+    <comment>At description</comment>
+  </data>
+  <data name="AtSpace" xml:space="preserve">
+    <value>La </value>
+    <comment>At description</comment>
+  </data>
+  <data name="AtX0" xml:space="preserve">
+    <value>la {0}</value>
+    <comment>AtX0 description</comment>
+  </data>
+  <data name="AtX0MinutesPastTheHour" xml:space="preserve">
+    <value>la și {0} minute</value>
+    <comment>AtX0MinutesPastTheHour description</comment>
+  </data>
+  <data name="AtX0SecondsPastTheMinute" xml:space="preserve">
+    <value>la și {0} secunde</value>
+    <comment>AtX0SecondsPastTheMinute description</comment>
+  </data>
+  <data name="BetweenX0AndX1" xml:space="preserve">
+    <value>între {0} și {1}</value>
+    <comment>BetweenX0AndX1 description</comment>
+  </data>
+  <data name="ComaBetweenDayX0AndX1OfTheMonth" xml:space="preserve">
+    <value>, între zilele {0} și {1} ale lunii</value>
+    <comment>BetweenDayX0AndX1OfTheMonth description</comment>
+  </data>
+  <data name="ComaEveryDay" xml:space="preserve">
+    <value>, în fiecare zi</value>
+    <comment>ComaEveryDay description</comment>
+  </data>
+  <data name="ComaEveryHour" xml:space="preserve">
+    <value>, în fiecare oră</value>
+    <comment>ComaEveryHour description</comment>
+  </data>
+  <data name="ComaEveryMinute" xml:space="preserve">
+    <value>, în fiecare minut</value>
+    <comment>ComaEveryMinute1 description</comment>
+  </data>
+  <data name="ComaEveryX0Days" xml:space="preserve">
+    <value>, la fiecare {0} zile</value>
+    <comment>ComaEveryX0Days description</comment>
+  </data>
+  <data name="ComaEveryX0DaysOfTheWeek" xml:space="preserve">
+    <value>, la fiecare a {0}-a zi a săptămânii</value>
+    <comment>EveryX0DaysOfTheWeek description</comment>
+  </data>
+  <data name="ComaEveryX0Months" xml:space="preserve">
+    <value>, la fiecare {0} luni</value>
+    <comment>EveryX0Months description</comment>
+  </data>
+  <data name="ComaEveryX0Years" xml:space="preserve">
+    <value>, o dată la {0} ani</value>
+    <comment>ComaEveryX0Years description</comment>
+  </data>
+  <data name="ComaOnDayX0OfTheMonth" xml:space="preserve">
+    <value>, în ziua {0} a lunii</value>
+    <comment>ComaOnDayX0OfTheMonth description</comment>
+  </data>
+  <data name="ComaOnlyInX0" xml:space="preserve">
+    <value>, doar în {0}</value>
+    <comment>ComaOnlyInX0 description</comment>
+  </data>
+  <data name="ComaOnlyOnX0" xml:space="preserve">
+    <value>, doar {0}</value>
+    <comment>OnlyOnX0 description</comment>
+  </data>
+  <data name="ComaOnThe" xml:space="preserve">
+    <value>, în </value>
+    <comment>OnThe description</comment>
+  </data>
+  <data name="ComaOnTheLastDayOfTheMonth" xml:space="preserve">
+    <value>, în ultima zi a lunii</value>
+    <comment>ComaOnTheLastDayOfTheMonth description</comment>
+  </data>
+  <data name="ComaOnTheLastWeekdayOfTheMonth" xml:space="preserve">
+    <value>, în ultima zi lucrătoare a lunii</value>
+    <comment>OnTheLastWeekdayOfTheMonth description</comment>
+  </data>
+  <data name="ComaOnTheLastX0OfTheMonth" xml:space="preserve">
+    <value>, în ultima {0} a lunii</value>
+    <comment>OnTheLastX0OfTheMonth description</comment>
+  </data>
+  <data name="ComaOnTheX0OfTheMonth" xml:space="preserve">
+    <value>, în {0} a lunii</value>
+    <comment>ComaOnTheX0OfTheMonth description</comment>
+  </data>
+  <data name="ComaX0ThroughX1" xml:space="preserve">
+    <value>, de {0} până {1}</value>
+    <comment>X0ThroughX1 description</comment>
+  </data>
+  <data name="EveryHour" xml:space="preserve">
+    <value>în fiecare oră</value>
+    <comment>EveryHour description</comment>
+  </data>
+  <data name="EveryMinute" xml:space="preserve">
+    <value>în fiecare minut</value>
+  </data>
+  <data name="EveryMinuteBetweenX0AndX1" xml:space="preserve">
+    <value>În fiecare minut între {0} și {1}</value>
+    <comment>EveryMinuteBetweenX0AndX1 description</comment>
+  </data>
+  <data name="EverySecond" xml:space="preserve">
+    <value>în fiecare secundă</value>
+    <comment>EverySecond description</comment>
+  </data>
+  <data name="EveryX0Hours" xml:space="preserve">
+    <value>la fiecare {0} ore</value>
+    <comment>EveryX0Hours description</comment>
+  </data>
+  <data name="EveryX0Minutes" xml:space="preserve">
+    <value>la fiecare {0} minute</value>
+    <comment>EveryX0Minutes description</comment>
+  </data>
+  <data name="EveryX0Seconds" xml:space="preserve">
+    <value>la fiecare {0} secunde</value>
+    <comment>EveryX0Seconds description</comment>
+  </data>
+  <data name="Fifth" xml:space="preserve">
+    <value>a cincea</value>
+    <comment>Fifth description</comment>
+  </data>
+  <data name="First" xml:space="preserve">
+    <value>prima</value>
+    <comment>First description</comment>
+  </data>
+  <data name="FirstWeekday" xml:space="preserve">
+    <value>prima zi a săptămânii</value>
+    <comment>FirstWeekday description</comment>
+  </data>
+  <data name="Forth" xml:space="preserve">
+    <value>a patra</value>
+    <comment>Forth description</comment>
+  </data>
+  <data name="MinutesX0ThroughX1PastTheHour" xml:space="preserve">
+    <value>între minutele {0} și {1}</value>
+    <comment>MinutesX0ThroughX1PastTheHour description</comment>
+  </data>
+  <data name="Second" xml:space="preserve">
+    <value>a doua</value>
+    <comment>Second description</comment>
+  </data>
+  <data name="SecondsX0ThroughX1PastTheMinute" xml:space="preserve">
+    <value>între secunda {0} și secunda {1}</value>
+    <comment>SecondsX0ThroughX1PastTheMinute description</comment>
+  </data>
+  <data name="SpaceAnd" xml:space="preserve">
+    <value> și</value>
+    <comment>And description</comment>
+  </data>
+  <data name="SpaceAndSpace" xml:space="preserve">
+    <value> și </value>
+    <comment>And description</comment>
+  </data>
+  <data name="SpaceX0OfTheMonth" xml:space="preserve">
+    <value> {0} a lunii</value>
+    <comment>X0OfTheMonth description</comment>
+  </data>
+  <data name="Third" xml:space="preserve">
+    <value>a treia</value>
+    <comment>Third description</comment>
+  </data>
+  <data name="WeekdayNearestDayX0" xml:space="preserve">
+    <value>cea mai apropiată zi a săptămânii de ziua {0}</value>
+    <comment>WeekdayNearestDayX0 description</comment>
+  </data>
+  <data name="ComaMinX0ThroughMinX1" xml:space="preserve">
+    <value>, de la {0} până la {1}</value>
+    <comment>X0ThroughX1 description</comment>
+  </data>
+  <data name="ComaMonthX0ThroughMonthX1" xml:space="preserve">
+    <value>, din {0} până în {1}</value>
+    <comment>from month/year x0 to month/year x1</comment>
+  </data>
+  <data name="ComaYearX0ThroughYearX1" xml:space="preserve">
+    <value>, din {0} până în {1}</value>
+    <comment>from year x0 to year x1</comment>
+  </data>
+  <data name="AtX0MinutesPastTheHourGt20" xml:space="preserve">
+    <value>la și {0} de minute</value>
+    <comment>&gt;20 min description</comment>
+  </data>
+  <data name="AtX0SecondsPastTheMinuteGt20" xml:space="preserve">
+    <value>la și {0} de secunde</value>
+    <comment>&gt;20 sec past the minute</comment>
+  </data>
+</root>


### PR DESCRIPTION
Decent Romanian translation. Missing the numeral attribute agreement in the genitive case. Forced to add some new resources due to the specificity of the Romanian language when specifying 'from x to y' or 'x through y' expressions.