### PR TITLE
No longer sign with a strong name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A .NET library that converts cron expressions into human readable descriptions.
  * Provides casing options (Sentence, Title, Lower, etc.)
  * Localization with support for 15 languages
  * Supports [Quartz Enterprise Scheduler .NET](https://www.quartz-scheduler.net/) cron expressions
- * Strongly-named assembly ([details](https://msdn.microsoft.com/en-us/library/wd40t7ad(v=vs.100).aspx))
 
 ## Download
 
@@ -121,6 +120,10 @@ Begining with version 2.0.0, the NuGet package will contain a library targeting 
 - ([More](https://github.com/dotnet/standard/blob/master/docs/versions.md))
 
 If your application is targeting an earlier version of .NET Framework (i.e. 4.0 or 3.5), you can use version `1.21.2` as it has support back to .NET Framework 3.5.  To install this version, run `Install-Package CronExpressionDescriptor -Version 1.21.2`.
+
+### Strong Name Signing
+
+If you need an assembly that is [signed with a strong name](https://msdn.microsoft.com/en-us/library/wd40t7ad(v=vs.100).aspx), you can use version 1.21.2 as it is currently the latest version signed with a strong name.
 
 ## Demo
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -51,7 +51,7 @@ csProj = csProj.replace(
 writeFile(libCsproj, csProj);
 
 // Build, pack, and push to NuGet
-eval(`dotnet build -c release -p:SignAssembly=True,PublicSign=True ${libCsproj}`);
+eval(`dotnet build -c release ${libCsproj}`);
 eval(`dotnet pack -c release --no-build ${libCsproj}`);
 eval(`dotnet nuget push ${releasePath}/${nupkgFile} -k ${env.NUGET_API_KEY}`);
 


### PR DESCRIPTION
Fixes #84 

No longer sign with a strong name

The .NET Core SDK does not support full signing on all platforms and only supports public key signing which has compatibility issues.

At a later time, signing with a strong name may be reintroduced but for now, I've added a note to README explaining that version 1.21.2 can be used for those that require strong name assemblies.