### PR TITLE
Add Swift to list of Ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ This library has been ported to several other languages.
  - PHP - [https://github.com/panlatent/cron-expression-descriptor](https://github.com/panlatent/cron-expression-descriptor)
  - Go - [https://github.com/lnquy/cron](https://github.com/lnquy/cron)
  - Rust - [https://github.com/cflockhart/cron-descriptor-rust](https://github.com/cflockhart/cron-descriptor-rust)
+ - Swift - [https://github.com/gooop/cron-descriptor-swift](https://github.com/gooop/cron-descriptor-swift)
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Hello, I recently ported `cRonstrue` (and by extension this repository) to Swift. I figured it would be worthwhile to add it to the list of ports here. Feel free to merge/reject as you please. 