### PR TITLE
Add Kyrgyz (ky) language translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The following language translations are available:
  * Ukrainian - uk ([Taras](https://github.com/tbudurovych))
  * Greek - el ([hardra1n](https://github.com/Hardra1n))
  * Kazakh - kk ([hardra1n](https://github.com/Hardra1n))
+ * Kyrgyz - ky ([Only Human](https://github.com/kgz77))
 
 To use one of these translations, pass in the `Locale` option to `GetDescription`.  For example, to get the description of `0-10 11 * * *` in German:
 

--- a/demo/Pages/Index.razor
+++ b/demo/Pages/Index.razor
@@ -19,6 +19,7 @@
             <option value="hu">Hungarian</option>
             <option value="it">Italian</option>
             <option value="ja">Japanese</option>
+            <option value="ky-KG">Kyrgyz</option>
             <option value="nb">Norwegian</option>
             <option value="pl">Polish</option>
             <option value="pt">Portuguese</option>

--- a/lib/CronExpressionDescriptor.csproj
+++ b/lib/CronExpressionDescriptor.csproj
@@ -12,7 +12,7 @@
     <Version>2.48.0</Version>
     <PackageReleaseNotes>See https://github.com/bradymholt/cron-expression-descriptor/releases for release notes</PackageReleaseNotes>
     <Authors>Brady Holt</Authors>
-    <Description>A library that converts cron expressions into human readable descriptions.  Supports multiple languages including: English, Brazillian, Spanish, Norwgian, Turkish, Dutch, Chinese Simplified, Russian, French, German, Ukrainian, Persian (Farsi), Polish, Romanian, Italian, Swedish, Slovenian, Danish, Finnish, Greek, Kazakh and Japanese.</Description>
+    <Description>A library that converts cron expressions into human readable descriptions.  Supports multiple languages including: English, Brazillian, Spanish, Norwgian, Turkish, Dutch, Chinese Simplified, Russian, French, German, Ukrainian, Persian (Farsi), Polish, Romanian, Italian, Swedish, Slovenian, Danish, Finnish, Greek, Kazakh, Kyrgyz and Japanese.</Description>
     <PackageLicense>https://github.com/bradymholt/cron-expression-descriptor/blob/master/LICENSE</PackageLicense>
     <PackageProjectUrl>https://github.com/bradymholt/cron-expression-descriptor</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/lib/ExpressionDescriptor.cs
+++ b/lib/ExpressionDescriptor.cs
@@ -12,7 +12,7 @@ namespace CronExpressionDescriptor
   public class ExpressionDescriptor
   {
     private readonly char[] m_specialCharacters = new char[] { '/', '-', ',', '*' };
-    private readonly string[] m_24hourTimeFormatTwoLetterISOLanguageName = new string[] { "ru", "uk", "de", "it", "tr", "pl", "ro", "da", "sl", "fi", "sv", "nb", "hu", "cs" };
+    private readonly string[] m_24hourTimeFormatTwoLetterISOLanguageName = new string[] { "ru", "uk", "de", "it", "tr", "pl", "ro", "da", "sl", "fi", "sv", "nb", "hu", "cs", "ky" };
 
     private string m_expression;
     private Options m_options;

--- a/lib/Resources.ky.resx
+++ b/lib/Resources.ky.resx
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="EveryMinute" xml:space="preserve">
+    <value>ар бир мүнөт сайын</value>
+  </data>
+  <data name="EveryHour" xml:space="preserve">
+    <value>ар саат сайын</value>
+    <comment>EveryHour description</comment>
+  </data>
+  <data name="AnErrorOccurredWhenGeneratingTheExpressionD" xml:space="preserve">
+    <value>Туюнтманын аныктамасын түзүүдө ката кетти. cron туюнтмасынын синтаксисин текшериңиз.</value>
+    <comment>AnErrorOccurredWhenGeneratingTheExpressionD description</comment>
+  </data>
+  <data name="AtSpace" xml:space="preserve">
+    <value>Саат </value>
+    <comment>At description</comment>
+  </data>
+  <data name="EveryMinuteBetweenX0AndX1" xml:space="preserve">
+    <value>{0} жана {1} аралыгында ар бир мүнөт сайын</value>
+    <comment>EveryMinuteBetweenX0AndX1 description</comment>
+  </data>
+  <data name="At" xml:space="preserve">
+    <value>Саат</value>
+    <comment>At description</comment>
+  </data>
+  <data name="SpaceAnd" xml:space="preserve">
+    <value> жана</value>
+    <comment>And description</comment>
+  </data>
+  <data name="EverySecond" xml:space="preserve">
+    <value>ар бир секунд сайын</value>
+    <comment>EverySecond description</comment>
+  </data>
+  <data name="EveryX0Seconds" xml:space="preserve">
+    <value>ар бир {0} секунд сайын</value>
+    <comment>EveryX0Seconds description</comment>
+  </data>
+  <data name="SecondsX0ThroughX1PastTheMinute" xml:space="preserve">
+    <value>мүнөттүн {0}-{1} секунддарында</value>
+    <comment>SecondsX0ThroughX1PastTheMinute description</comment>
+  </data>
+  <data name="AtX0SecondsPastTheMinute" xml:space="preserve">
+    <value>мүнөттүн {0}-секундунда</value>
+    <comment>AtX0SecondsPastTheMinute description</comment>
+  </data>
+  <data name="EveryX0Minutes" xml:space="preserve">
+    <value>ар бир {0} мүнөт сайын</value>
+    <comment>EveryX0Minutes description</comment>
+  </data>
+  <data name="MinutesX0ThroughX1PastTheHour" xml:space="preserve">
+    <value>сааттын {0}-{1} мүнөттөрүндө</value>
+    <comment>MinutesX0ThroughX1PastTheHour description</comment>
+  </data>
+  <data name="AtX0MinutesPastTheHour" xml:space="preserve">
+    <value>сааттын {0}-мүнөтүндө</value>
+    <comment>AtX0MinutesPastTheHour description</comment>
+  </data>
+  <data name="EveryX0Hours" xml:space="preserve">
+    <value>ар бир {0} саат сайын</value>
+    <comment>EveryX0Hours description</comment>
+  </data>
+  <data name="BetweenX0AndX1" xml:space="preserve">
+    <value>{0} жана {1} аралыгында</value>
+    <comment>BetweenX0AndX1 description</comment>
+  </data>
+  <data name="AtX0" xml:space="preserve">
+    <value>саат {0} өзүндө</value>
+    <comment>AtX0 description</comment>
+  </data>
+  <data name="ComaEveryDay" xml:space="preserve">
+    <value>, күн сайын</value>
+    <comment>ComaEveryDay description</comment>
+  </data>
+  <data name="ComaEveryX0DaysOfTheWeek" xml:space="preserve">
+    <value>, аптанын ар бир {0} күнү сайын</value>
+    <comment>EveryX0DaysOfTheWeek description</comment>
+  </data>
+  <data name="ComaEveryX0Weeks" xml:space="preserve">
+    <value>, ар бир {0} апта сайын</value>
+    <comment>ComaEveryX0Weeks description</comment>
+  </data>
+  <data name="ComaX0ThroughX1" xml:space="preserve">
+    <value>, {0}-{1}</value>
+    <comment>X0ThroughX1 description</comment>
+  </data>
+  <data name="First" xml:space="preserve">
+    <value>биринчи</value>
+    <comment>First description</comment>
+  </data>
+  <data name="Second" xml:space="preserve">
+    <value>экинчи</value>
+    <comment>Second description</comment>
+  </data>
+  <data name="Third" xml:space="preserve">
+    <value>үчүнчү</value>
+    <comment>Third description</comment>
+  </data>
+  <data name="Fourth" xml:space="preserve">
+    <value>төртүнчү</value>
+    <comment>Fourth description</comment>
+  </data>
+  <data name="Fifth" xml:space="preserve">
+    <value>бешинчи</value>
+    <comment>Fifth description</comment>
+  </data>
+  <data name="ComaOnThe" xml:space="preserve">
+    <value>, ушул убакта: </value>
+    <comment>OnThe description</comment>
+  </data>
+  <data name="SpaceX0OfTheMonth" xml:space="preserve">
+    <value> айдын {0}</value>
+    <comment>X0OfTheMonth description</comment>
+  </data>
+  <data name="ComaOnTheLastX0OfTheMonth" xml:space="preserve">
+    <value>, айдын акыркы {0} күнүндө</value>
+    <comment>OnTheLastX0OfTheMonth description</comment>
+  </data>
+  <data name="ComaOnlyOnX0" xml:space="preserve">
+    <value>, бир гана {0} күндөрү</value>
+    <comment>OnlyOnX0 description</comment>
+  </data>
+  <data name="ComaOrOnX0" xml:space="preserve">
+    <value>, же {0} күндөрү</value>
+    <comment>ComaOrOnX0 description - used when both day-of-month and day-of-week are specified (OR logic)</comment>
+  </data>
+  <data name="ComaEveryX0Months" xml:space="preserve">
+    <value>, ар бир {0} ай сайын</value>
+    <comment>EveryX0Months description</comment>
+  </data>
+  <data name="ComaOnlyInX0" xml:space="preserve">
+    <value>, бир гана {0} ичинде</value>
+    <comment>ComaOnlyInX0 description</comment>
+  </data>
+  <data name="ComaOnTheLastDayOfTheMonth" xml:space="preserve">
+    <value>, айдын акыркы күнүндө</value>
+    <comment>ComaOnTheLastDayOfTheMonth description</comment>
+  </data>
+  <data name="ComaOnTheLastWeekdayOfTheMonth" xml:space="preserve">
+    <value>, айдын акыркы иш күнүндө</value>
+    <comment>OnTheLastWeekdayOfTheMonth description</comment>
+  </data>
+  <data name="FirstWeekday" xml:space="preserve">
+    <value>биринчи иш күнү</value>
+    <comment>FirstWeekday description</comment>
+  </data>
+  <data name="WeekdayNearestDayX0" xml:space="preserve">
+    <value>{0}-күнгө эң жакын иш күнү</value>
+    <comment>WeekdayNearestDayX0 description</comment>
+  </data>
+  <data name="ComaOnTheX0OfTheMonth" xml:space="preserve">
+    <value>, айдын {0} күнүндө</value>
+    <comment>ComaOnTheX0OfTheMonth description</comment>
+  </data>
+  <data name="ComaEveryX0Days" xml:space="preserve">
+    <value>, ар бир {0} күн сайын</value>
+    <comment>ComaEveryX0Days description</comment>
+  </data>
+  <data name="ComaBetweenDayX0AndX1OfTheMonth" xml:space="preserve">
+    <value>, айдын {0} жана {1} күндөрүнүн аралыгында</value>
+    <comment>BetweenDayX0AndX1OfTheMonth description</comment>
+  </data>
+  <data name="ComaOnDayX0OfTheMonth" xml:space="preserve">
+    <value>, айдын {0}-күнүндө</value>
+    <comment>ComaOnDayX0OfTheMonth description</comment>
+  </data>
+  <data name="SpaceAndSpace" xml:space="preserve">
+    <value> жана </value>
+    <comment>And description</comment>
+  </data>
+  <data name="ComaEveryMinute" xml:space="preserve">
+    <value>, ар бир мүнөт сайын</value>
+    <comment>ComaEveryMinute1 description</comment>
+  </data>
+  <data name="ComaEveryHour" xml:space="preserve">
+    <value>, ар саат сайын</value>
+    <comment>ComaEveryHour description</comment>
+  </data>
+  <data name="ComaEveryX0Years" xml:space="preserve">
+    <value>, ар бир {0} жыл сайын</value>
+    <comment>ComaEveryX0Years description</comment>
+  </data>
+  <data name="CommaStartingX0" xml:space="preserve">
+    <value>, {0} баштап</value>
+    <comment>CommaStartingX0 description</comment>
+  </data>
+  <data name="AMPeriod" xml:space="preserve">
+    <value>AM</value>
+    <comment>Placeholder for 24-hour format safety</comment>
+  </data>
+  <data name="PMPeriod" xml:space="preserve">
+    <value>PM</value>
+    <comment>Placeholder for 24-hour format safety</comment>
+  </data>
+  <data name="CommaDaysBeforeTheLastDayOfTheMonth" xml:space="preserve">
+    <value>, айдын акыркы күнүнө чейин {0} күн калганда</value>
+    <comment>CommaDaysBeforeTheLastDayOfTheMonth description</comment>
+  </data>
+  <data name="ComaOnlyInYearX0" xml:space="preserve">
+    <value>, бир гана {0}-жылы</value>
+  </data>
+</root>

--- a/test/TestFormats.ky.cs
+++ b/test/TestFormats.ky.cs
@@ -1,0 +1,371 @@
+using Xunit;
+using Assert = CronExpressionDescriptor.Test.Support.AssertExtensions;
+
+namespace CronExpressionDescriptor.Test
+{
+  /// <summary>
+  /// Tests for Kyrgyz translation
+  /// </summary>
+  public class TestFormatsKY : Support.BaseTestFormats
+  {
+    protected override string GetLocale()
+    {
+      return "ky-KG";
+    }
+
+    [Fact]
+    public void TestEveryMinute()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын", GetDescription("* * * * *"));
+    }
+
+    [Fact]
+    public void TestEvery1Minute()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын", GetDescription("*/1 * * * *"));
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын", GetDescription("0 0/1 * * * ?"));
+    }
+
+    [Fact]
+    public void TestEveryHour()
+    {
+      Assert.EqualsCaseInsensitive("Ар саат сайын", GetDescription("0 0 * * * ?"));
+      Assert.EqualsCaseInsensitive("Ар саат сайын", GetDescription("0 0 0/1 * * ?"));
+    }
+
+    [Fact]
+    public void TestTimeOfDayCertainDaysOfWeek()
+    {
+      Assert.EqualsCaseInsensitive("Саат 23:00, дүйшөмбү-жума", GetDescription("0 23 ? * MON-FRI"));
+    }
+
+    [Fact]
+    public void TestEverySecond()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир секунд сайын", GetDescription("* * * * * *"));
+    }
+
+    [Fact]
+    public void TestEvery45Seconds()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 45 секунд сайын", GetDescription("*/45 * * * * *"));
+    }
+
+    [Fact]
+    public void TestEvery5Minutes()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 5 мүнөт сайын", GetDescription("*/5 * * * *"));
+      Assert.EqualsCaseInsensitive("Ар бир 10 мүнөт сайын", GetDescription("0 0/10 * * * ?"));
+    }
+
+    [Fact]
+    public void TestEvery5MinutesOnTheSecond()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 5 мүнөт сайын", GetDescription("0 */5 * * * *"));
+    }
+
+    [Fact]
+    public void TestWeekdaysAtTime()
+    {
+      Assert.EqualsCaseInsensitive("Саат 11:30, дүйшөмбү-жума", GetDescription("30 11 * * 1-5"));
+    }
+
+    [Fact]
+    public void TestDailyAtTime()
+    {
+      Assert.EqualsCaseInsensitive("Саат 11:30", GetDescription("30 11 * * *"));
+    }
+
+    [Fact]
+    public void TestMinuteSpan()
+    {
+      Assert.EqualsCaseInsensitive("11:00 жана 11:10 аралыгында ар бир мүнөт сайын", GetDescription("0-10 11 * * *"));
+    }
+
+    [Fact]
+    public void TestOneMonthOnly()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, бир гана Март ичинде", GetDescription("* * * 3 *"));
+    }
+
+    [Fact]
+    public void TestTwoMonthsOnly()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, бир гана Март жана Июнь ичинде", GetDescription("* * * 3,6 *"));
+    }
+
+    [Fact]
+    public void TestTwoTimesEachAfternoon()
+    {
+      Assert.EqualsCaseInsensitive("Саат 14:30 жана 16:30", GetDescription("30 14,16 * * *"));
+    }
+
+    [Fact]
+    public void TestThreeTimesDaily()
+    {
+      Assert.EqualsCaseInsensitive("Саат 06:30, 14:30 жана 16:30", GetDescription("30 6,14,16 * * *"));
+    }
+
+    [Fact]
+    public void TestOnceAWeek()
+    {
+      Assert.EqualsCaseInsensitive("Саат 09:46, бир гана дүйшөмбү күндөрү", GetDescription("46 9 * * 1"));
+    }
+
+    [Fact]
+    public void TestDayOfMonth()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, айдын 15-күнүндө", GetDescription("23 12 15 * *"));
+    }
+
+    [Fact]
+    public void TestMonthName()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, бир гана Январь ичинде", GetDescription("23 12 * JAN *"));
+    }
+
+    [Fact]
+    public void TestDayOfMonthWithQuestionMark()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, бир гана Январь ичинде", GetDescription("23 12 ? JAN *"));
+    }
+
+    [Fact]
+    public void TestMonthNameRange2()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, Январь-Февраль", GetDescription("23 12 * JAN-FEB *"));
+    }
+
+    [Fact]
+    public void TestMonthNameRange3()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, Январь-Март", GetDescription("23 12 * JAN-MAR *"));
+    }
+
+    [Fact]
+    public void TestDayOfWeekName()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, бир гана жекшемби күндөрү", GetDescription("23 12 * * SUN"));
+    }
+
+    [Fact]
+    public void TestDayOfWeekRange()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 5 мүнөт сайын, 15:00 жана 15:59 аралыгында, дүйшөмбү-жума", GetDescription("*/5 15 * * MON-FRI"));
+    }
+
+    [Fact]
+    public void TestDayOfWeekOnceInMonth()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, ушул убакта: үчүнчү айдын дүйшөмбү", GetDescription("* * * * MON#3"));
+    }
+
+    [Fact]
+    public void TestLastDayOfTheWeekOfTheMonth()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, айдын акыркы бейшемби күнүндө", GetDescription("* * * * 4L"));
+    }
+
+    [Fact]
+    public void TestLastDayOfTheMonth()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 5 мүнөт сайын, айдын акыркы күнүндө, бир гана Январь ичинде", GetDescription("*/5 * L JAN *"));
+    }
+
+    [Fact]
+    public void TestLastWeekdayOfTheMonth()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, айдын акыркы иш күнүндө", GetDescription("* * LW * *"));
+    }
+
+    [Fact]
+    public void TestLastWeekdayOfTheMonth2()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, айдын акыркы иш күнүндө", GetDescription("* * WL * *"));
+    }
+
+    [Fact]
+    public void TestFirstWeekdayOfTheMonth()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, айдын биринчи иш күнү күнүндө", GetDescription("* * 1W * *"));
+    }
+
+    [Fact]
+    public void TestFirstWeekdayOfTheMonth2()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, айдын биринчи иш күнү күнүндө", GetDescription("* * W1 * *"));
+    }
+
+    [Fact]
+    public void TestParticularWeekdayOfTheMonth()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, айдын 5-күнгө эң жакын иш күнү күнүндө", GetDescription("* * 5W * *"));
+    }
+
+    [Fact]
+    public void TestParticularWeekdayOfTheMonth2()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, айдын 5-күнгө эң жакын иш күнү күнүндө", GetDescription("* * W5 * *"));
+    }
+
+    [Fact]
+    public void TestTimeOfDayWithSeconds()
+    {
+      Assert.EqualsCaseInsensitive("Саат 14:02:30", GetDescription("30 02 14 * * *"));
+    }
+
+    [Fact]
+    public void TestSecondInternvals()
+    {
+      Assert.EqualsCaseInsensitive("Мүнөттүн 5-10 секунддарында", GetDescription("5-10 * * * * *"));
+    }
+
+    [Fact]
+    public void TestSecondMinutesHoursIntervals()
+    {
+      Assert.EqualsCaseInsensitive("Мүнөттүн 5-10 секунддарында, сааттын 30-35 мүнөттөрүндө, 10:00 жана 12:59 аралыгында", GetDescription("5-10 30-35 10-12 * * *"));
+    }
+
+    [Fact]
+    public void TestEvery5MinutesAt30Seconds()
+    {
+      Assert.EqualsCaseInsensitive("Мүнөттүн 30-секундунда, ар бир 5 мүнөт сайын", GetDescription("30 */5 * * * *"));
+    }
+
+    [Fact]
+    public void TestMinutesPastTheHourRange()
+    {
+      Assert.EqualsCaseInsensitive("Сааттын 30-мүнөтүндө, 10:00 жана 13:59 аралыгында, бир гана шаршемби жана жума күндөрү", GetDescription("0 30 10-13 ? * WED,FRI"));
+    }
+
+    [Fact]
+    public void TestSecondsPastTheMinuteInterval()
+    {
+      Assert.EqualsCaseInsensitive("Мүнөттүн 10-секундунда, ар бир 5 мүнөт сайын", GetDescription("10 0/5 * * * ?"));
+    }
+
+    [Fact]
+    public void TestBetweenWithInterval()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 3 мүнөт сайын, сааттын 2-59 мүнөттөрүндө, саат 01:00, 09:00, жана 22:00 өзүндө, айдын 11 жана 26 күндөрүнүн аралыгында, Январь-Июнь", GetDescription("2-59/3 1,9,22 11-26 1-6 ?"));
+    }
+
+    [Fact]
+    public void TestRecurringFirstOfMonth()
+    {
+      Assert.EqualsCaseInsensitive("Саат 06:00", GetDescription("0 0 6 1/1 * ?"));
+    }
+
+    [Fact]
+    public void TestMinutesPastTheHour()
+    {
+      Assert.EqualsCaseInsensitive("Сааттын 5-мүнөтүндө", GetDescription("0 5 0/1 * * ?"));
+    }
+
+    [Fact]
+    public void TestOneYearOnlyWithSeconds()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир секунд сайын, бир гана 2013-жылы", GetDescription("* * * * * * 2013"));
+    }
+
+    [Fact]
+    public void TestOneYearOnlyWithoutSeconds()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, бир гана 2013-жылы", GetDescription("* * * * * 2013"));
+    }
+
+    [Fact]
+    public void TestTwoYearsOnly()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир мүнөт сайын, бир гана 2013 жана 2014-жылы", GetDescription("* * * * * 2013,2014"));
+    }
+
+    [Fact]
+    public void TestYearRange2()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, Январь-Февраль, 2013-2014", GetDescription("23 12 * JAN-FEB * 2013-2014"));
+    }
+
+    [Fact]
+    public void TestYearRange3()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, Январь-Март, 2013-2015", GetDescription("23 12 * JAN-MAR * 2013-2015"));
+    }
+
+    [Fact]
+    public void TestHourRange()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 30 мүнөт сайын, 08:00 жана 09:59 аралыгында, айдын 5 жана 20-күнүндө", GetDescription("0 0/30 8-9 5,20 * ?"));
+    }
+
+    [Fact]
+    public void TestDayOfWeekModifier()
+    {
+      Assert.EqualsCaseInsensitive("Саат 12:23, ушул убакта: экинчи айдын жекшемби", GetDescription("23 12 * * SUN#2"));
+    }
+
+    [Fact]
+    public void TestDayOfWeekModifierWithSundayStartOne()
+    {
+      Options options = new Options();
+      options.DayOfWeekStartIndexZero = false;
+
+      Assert.EqualsCaseInsensitive("Саат 12:23, ушул убакта: экинчи айдын жекшемби", GetDescription("23 12 * * 1#2", options));
+    }
+
+    [Fact]
+    public void TestHourRangeWithEveryPortion()
+    {
+      Assert.EqualsCaseInsensitive("Сааттын 25-мүнөтүндө, ар бир 13 саат сайын, 07:00 жана 19:59 аралыгында", GetDescription("0 25 7-19/13 ? * *"));
+    }
+
+    [Fact]
+    public void TestHourRangeWithTrailingZeroWithEveryPortion()
+    {
+      Assert.EqualsCaseInsensitive("Сааттын 25-мүнөтүндө, ар бир 13 саат сайын, 07:00 жана 20:59 аралыгында", GetDescription("0 25 7-20/13 ? * *"));
+    }
+
+    [Fact]
+    public void TestSecondsInternalWithStepValue()
+    {
+      // GitHub Issue #49: https://github.com/bradymholt/cron-expression-descriptor/issues/49
+      Assert.EqualsCaseInsensitive("Ар бир 30 секунд сайын, мүнөттүн 5-секундунда баштап", GetDescription("5/30 * * * * ?"));
+    }
+
+    [Fact]
+    public void TestMinutesInternalWithStepValue()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир 30 мүнөт сайын, сааттын 5-мүнөтүндө баштап", GetDescription("0 5/30 * * * ?"));
+    }
+
+    [Fact]
+    public void TestHoursInternalWithStepValue()
+    {
+      Assert.EqualsCaseInsensitive("Ар бир секунд сайын, ар бир 8 саат сайын, саат 05:00 өзүндө баштап", GetDescription("* * 5/8 * * ?"));
+    }
+
+    [Fact]
+    public void TestDayOfMonthInternalWithStepValue()
+    {
+      Assert.EqualsCaseInsensitive("Саат 07:05, ар бир 3 күн сайын, айдын 2-күнүндө баштап", GetDescription("0 5 7 2/3 * ? *"));
+    }
+
+    [Fact]
+    public void TestMonthInternalWithStepValue()
+    {
+      Assert.EqualsCaseInsensitive("Саат 07:05, ар бир 2 ай сайын, Март-Декабрь", GetDescription("0 5 7 ? 3/2 ? *"));
+    }
+
+    [Fact]
+    public void TestDayOfWeekInternalWithStepValue()
+    {
+      Assert.EqualsCaseInsensitive("Саат 07:05, аптанын ар бир 3 күнү сайын, шейшемби-ишемби", GetDescription("0 5 7 ? * 2/3 *"));
+    }
+
+    [Fact]
+    public void TestYearInternalWithStepValue()
+    {
+      Assert.EqualsCaseInsensitive("Саат 07:05, ар бир 4 жыл сайын, 2016-9999", GetDescription("0 5 7 ? * ? 2016/4"));
+    }
+  }
+}


### PR DESCRIPTION
- Add lib/Resources.ky.resx with Kyrgyz (Cyrillic) translations for all resource keys, including the ComaEveryX0Weeks key.
- Default the Kyrgyz locale to a 24-hour clock by adding "ky" to m_24hourTimeFormatTwoLetterISOLanguageName in ExpressionDescriptor.cs (Kyrgyzstan conventionally uses 24-hour time).
- Add test/TestFormats.ky.cs (locale ky-KG) covering all description formats, mirroring the existing language test suites.
- Register the language: README.md i18n list, <Description/> in CronExpressionDescriptor.csproj, and the demo language selector.