### PR TITLE
fix(i18n): add missing German translation for ComaEveryX0Weeks

### DIFF
--- a/lib/Resources.de.resx
+++ b/lib/Resources.de.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -191,6 +191,9 @@
   <data name="ComaEveryX0DaysOfTheWeek" xml:space="preserve">
     <value>, alle {0} Tage der Woche</value>
     <comment>EveryX0DaysOfTheWeek description</comment>
+  </data>
+  <data name="ComaEveryX0Weeks" xml:space="preserve">
+    <value>, alle {0} Wochen</value>
   </data>
   <data name="ComaX0ThroughX1" xml:space="preserve">
     <value>, {0} bis {1}</value>

--- a/test/TestFormats.de.cs
+++ b/test/TestFormats.de.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 namespace CronExpressionDescriptor.Test
 {
@@ -367,6 +367,12 @@ namespace CronExpressionDescriptor.Test
         public void TestYearInternalWithStepValue()
         {
             Assert.Equal("Um 07:05, alle 4 Jahre, 2016 bis 9999", GetDescription("0 5 7 ? * ? 2016/4"));
+        }
+
+        [Fact]
+        public void TestWeekInternalWithStepValue()
+        {
+            Assert.Equal("Jede Minute, alle 2 Wochen, nur am Freitag", GetDescription("* * * * 5/2"));
         }
     }
 }


### PR DESCRIPTION
Adds the missing German translation for `ComaEveryX0Weeks`